### PR TITLE
fix_include_problem_lv_refr_h

### DIFF
--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -18,7 +18,11 @@
 
 #include "driver/i2c.h"
 
+#ifdef LV_LVGL_H_INCLUDE_SIMPLE
+#include "src/lv_core/lv_refr.h"
+#else
 #include "lvgl/src/lv_core/lv_refr.h"
+#endif
 
 /*********************
  *      DEFINES


### PR DESCRIPTION
using v7.8 and later needs to remove the leading "lvgl" from the include path for `lv_refr.h`.  This PR uses LV_LVGL_H_INCLUDE_SIMPLE as the condition the same way `lvgl.h` is referenced.