### PR TITLE
Changed display rotation macro

### DIFF
--- a/lvgl_tft/ssd1306.c
+++ b/lvgl_tft/ssd1306.c
@@ -106,10 +106,10 @@ void ssd1306_init()
 	i2c_master_write_byte(cmd, OLED_CMD_SET_CHARGE_PUMP, true);
 	i2c_master_write_byte(cmd, 0x14, true);
 
-#if defined (CONFIG_DISPLAY_ORIENTATION_PORTRAIT)
+#if defined (CONFIG_DISPLAY_ORIENTATION_LANDSCAPE)
         i2c_master_write_byte(cmd, OLED_CMD_SET_SEGMENT_REMAP, true);
 	i2c_master_write_byte(cmd, OLED_CMD_SET_COM_SCAN_MODE_REMAP, true);
-#elif defined (CONFIG_DISPLAY_ORIENTATION_PORTRAIT_INVERTED)
+#elif defined (CONFIG_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED)
         i2c_master_write_byte(cmd, 0xA0, true);
         i2c_master_write_byte(cmd, OLED_CMD_SET_COM_SCAN_MODE_NORMAL, true);
 #else


### PR DESCRIPTION
Earlier it used `DISPLAY_ORIENTATION_PORTRAIT` and `DISPLAY_ORIENTATION_PORTRAIT_INVERTED` macro, which is wrong. It doesn't make sense in a ssd1306. It should be `DISPLAY_ORIENTATION_LANDSCAPE` and `DISPLAY_ORIENTATION_LANDSCAPE_INVERTED` 