### PR TITLE
Fix/config orientation naming

### DIFF
--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -186,23 +186,23 @@ menu "LVGL TFT Display controller"
     # Used in display init function to send display orientation commands
     choice DISPLAY_ORIENTATION
         prompt "Display orientation"
-        default DISPLAY_ORIENTATION_PORTRAIT
-        config DISPLAY_ORIENTATION_PORTRAIT
+        default LV_DISPLAY_ORIENTATION_PORTRAIT
+        config LV_DISPLAY_ORIENTATION_PORTRAIT
             bool "Portrait"
-        config DISPLAY_ORIENTATION_PORTRAIT_INVERTED
+        config LV_DISPLAY_ORIENTATION_PORTRAIT_INVERTED
             bool "Portrait inverted"
-        config DISPLAY_ORIENTATION_LANDSCAPE
+        config LV_DISPLAY_ORIENTATION_LANDSCAPE
             bool "Landscape"
-        config DISPLAY_ORIENTATION_LANDSCAPE_INVERTED
+        config LV_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED
             bool "Landscape inverted"
     endchoice
 
     config LV_DISPLAY_ORIENTATION
         int
-        default 0 if DISPLAY_ORIENTATION_PORTRAIT
-        default 1 if DISPLAY_ORIENTATION_PORTRAIT_INVERTED
-        default 2 if DISPLAY_ORIENTATION_LANDSCAPE
-        default 3 if DISPLAY_ORIENTATION_LANDSCAPE_INVERTED
+        default 0 if LV_DISPLAY_ORIENTATION_PORTRAIT
+        default 1 if LV_DISPLAY_ORIENTATION_PORTRAIT_INVERTED
+        default 2 if LV_DISPLAY_ORIENTATION_LANDSCAPE
+        default 3 if LV_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED
 
     config LV_TFT_DISPLAY_OFFSETS
         bool

--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -735,6 +735,19 @@ menu "LVGL TFT Display controller"
     endmenu
 
     # menu will be visible only when LV_PREDEFINED_DISPLAY_NONE is y
+    menu "Display ST7789 Configuration"
+    visible if LV_TFT_DISPLAY_CONTROLLER_ST7789
+
+        config LV_DISP_ST7789_SOFT_RESET
+            bool "Soft reset - use software reset instead of reset pin"
+            depends on LV_TFT_DISPLAY_CONTROLLER_ST7789            
+            default n
+            help
+                Use software reset and ignores configured reset pin (some hardware does not use a reset pin).
+    
+    endmenu
+
+    # menu will be visible only when LV_PREDEFINED_DISPLAY_NONE is y
     menu "Display Pin Assignments"
     visible if LV_PREDEFINED_DISPLAY_NONE || LV_PREDEFINED_DISPLAY_RPI_MPI3501 || LV_PREDEFINED_PINS_TKOALA
 

--- a/lvgl_tft/ssd1306.c
+++ b/lvgl_tft/ssd1306.c
@@ -101,10 +101,10 @@ void ssd1306_init(void)
     uint8_t orientation_1 = 0;
     uint8_t orientation_2 = 0;
 
-#if defined (CONFIG_DISPLAY_ORIENTATION_PORTRAIT)
+#if defined (CONFIG_LV_DISPLAY_ORIENTATION_PORTRAIT)
     orientation_1 = OLED_CMD_SET_SEGMENT_REMAP;
     orientation_2 = OLED_CMD_SET_COM_SCAN_MODE_REMAP;
-#elif defined (CONFIG_DISPLAY_ORIENTATION_PORTRAIT_INVERTED)
+#elif defined (CONFIG_LV_DISPLAY_ORIENTATION_PORTRAIT_INVERTED)
     orientation_1 = 0xA0;
     orientation_2 = OLED_CMD_SET_COM_SCAN_MODE_NORMAL;
 #else

--- a/lvgl_tft/st7789.c
+++ b/lvgl_tft/st7789.c
@@ -84,8 +84,11 @@ void st7789_init(void)
     //Initialize non-SPI GPIOs
     gpio_pad_select_gpio(ST7789_DC);
     gpio_set_direction(ST7789_DC, GPIO_MODE_OUTPUT);
+
+#if !defined(CONFIG_LV_DISP_ST7789_SOFT_RESET)
     gpio_pad_select_gpio(ST7789_RST);
     gpio_set_direction(ST7789_RST, GPIO_MODE_OUTPUT);
+#endif
     
 #if ST7789_ENABLE_BACKLIGHT_CONTROL
     gpio_pad_select_gpio(ST7789_BCKL);
@@ -93,10 +96,14 @@ void st7789_init(void)
 #endif
 
     //Reset the display
+#if !defined(CONFIG_LV_DISP_ST7789_SOFT_RESET)
     gpio_set_level(ST7789_RST, 0);
     vTaskDelay(100 / portTICK_RATE_MS);
     gpio_set_level(ST7789_RST, 1);
     vTaskDelay(100 / portTICK_RATE_MS);
+#else
+    st7789_send_cmd(ST7789_SWRESET);
+#endif
 
     printf("ST7789 initialization.\n");
 


### PR DESCRIPTION
All the drivers seem to use the configuration values in the form `CONFIG_LV_DISPLAY_ORIENTATION_XXX` except for the SSD1306 driver.  Also, there are not settings of the form `CONFIG_LV_DISPLAY_ORIENTATION_XXX` in Kconfig.  This PR attempts to standardize the orientation naming in Kconfig and the SSD1306 driver.