### PR TITLE
Remove AXP192 symbols being created when it shouldn't

### DIFF
--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -601,7 +601,8 @@ menu "LVGL TFT Display controller"
             power management in your own code.
 
     config LV_AXP192_PIN_SDA
-        int "GPIO for AXP192 I2C SDA" if LV_M5STICKC_HANDLE_AXP192
+        int "GPIO for AXP192 I2C SDA"
+        depends on LV_M5STICKC_HANDLE_AXP192
         range 0 39
         default 21 if LV_PREDEFINED_DISPLAY_M5STICKC
         default 21
@@ -609,7 +610,8 @@ menu "LVGL TFT Display controller"
             Configure the AXP192 I2C SDA pin here.
 
     config LV_AXP192_PIN_SCL
-        int "GPIO for AXP192 I2C SCL" if LV_M5STICKC_HANDLE_AXP192
+        int "GPIO for AXP192 I2C SCL"
+        depends on LV_M5STICKC_HANDLE_AXP192
         range 0 39
         default 22 if LV_PREDEFINED_DISPLAY_M5STICKC
         default 22


### PR DESCRIPTION
AXP192 symbols were created by default, they shouldn't