### PR TITLE
SSD1306: Fix orientation symbol names

### DIFF
--- a/lvgl_tft/ssd1306.c
+++ b/lvgl_tft/ssd1306.c
@@ -101,10 +101,10 @@ void ssd1306_init(void)
     uint8_t orientation_1 = 0;
     uint8_t orientation_2 = 0;
 
-#if defined (CONFIG_LV_DISPLAY_ORIENTATION_LANDSCAPE)
+#if defined (CONFIG_DISPLAY_ORIENTATION_LANDSCAPE)
     orientation_1 = OLED_CMD_SET_SEGMENT_REMAP;
     orientation_2 = OLED_CMD_SET_COM_SCAN_MODE_REMAP;
-#elif defined (CONFIG_LV_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED)
+#elif defined (CONFIG_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED)
     orientation_1 = 0xA0;
     orientation_2 = OLED_CMD_SET_COM_SCAN_MODE_NORMAL;
 #else


### PR DESCRIPTION
Kconfig sets CONFIG_DISPLAY_ORIENTATION_LANDSCAPE and CONFIG_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED.
This commit replaces the old references to CONFIG_LV_DISPLAY_ORIENTATION_LANDSCAPE and
CONFIG_LV_DISPLAY_ORIENTATION_LANDSCAPE_INVERTED.

Fixes: #48