### PR TITLE
Fix contrast and display mode initialisation

### DIFF
--- a/lvgl_tft/ssd1306.c
+++ b/lvgl_tft/ssd1306.c
@@ -126,8 +126,8 @@ void ssd1306_init(void)
         orientation_1,
         orientation_2,
         OLED_CMD_SET_CONTRAST,
-        display_mode,
         0xFF,
+        display_mode,
         OLED_CMD_DISPLAY_ON
     };
 


### PR DESCRIPTION
### Description of the fix
The double byte command OLED_CMD_SET_CONTRAST (SSD1306 datasheet rev 1.1 p.28) was followed by display_mode.
So the contrast was set to 0xA6 or 0xA7 depending on the display mode configured and the display mode itself wasn't configurable.
See the issue #53 for more details.