### PR TITLE
FT6X36 touch: fixed axis-swap, Kconfig defaults.

### DIFF
--- a/lvgl_touch/Kconfig
+++ b/lvgl_touch/Kconfig
@@ -239,20 +239,20 @@ menu "LVGL Touch controller"
     menu "Touchpanel Configuration (FT6X06)"
         depends on LV_TOUCH_CONTROLLER_FT6X06
 
-	config LV_FT6X36_SWAPXY
-	    bool
-	    prompt "Swap X with Y coordinate."
-	    default y
+        config LV_FT6X36_SWAPXY
+            bool
+            prompt "Swap X with Y coordinate."
+            default n
 
         config LV_FT6X36_INVERT_X
             bool
             prompt "Invert X coordinate value."
             default n
 
-        config LV_FT6X36_INVERT_Y
-            bool
-            prompt "Invert Y coordinate value."
-            default y
+            config LV_FT6X36_INVERT_Y
+                bool
+                prompt "Invert Y coordinate value."
+                default n
 
     endmenu
     

--- a/lvgl_touch/ft6x36.c
+++ b/lvgl_touch/ft6x36.c
@@ -182,20 +182,20 @@ bool ft6x36_read(lv_indev_drv_t *drv, lv_indev_data_t *data) {
     last_x = ((data_xy[0] & FT6X36_MSB_MASK) << 8) | (data_xy[1] & FT6X36_LSB_MASK);
     last_y = ((data_xy[2] & FT6X36_MSB_MASK) << 8) | (data_xy[3] & FT6X36_LSB_MASK);
 
-#if CONFIG_LV_FT6X36_SWAPXY
-    int16_t swap_buf = last_x;
-    last_x = last_y;
-    last_y = swap_buf;
-#endif
 #if CONFIG_LV_FT6X36_INVERT_X
     last_x =  LV_HOR_RES - last_x;
 #endif
 #if CONFIG_LV_FT6X36_INVERT_Y
     last_y = LV_VER_RES - last_y;
 #endif
+#if CONFIG_LV_FT6X36_SWAPXY
+    int16_t swap_buf = last_x;
+    last_x = last_y;
+    last_y = swap_buf;
+#endif
     data->point.x = last_x;
     data->point.y = last_y;
     data->state = LV_INDEV_STATE_PR;
-    ESP_LOGV(TAG, "X=%u Y=%u", data->point.x, data->point.y);
+    ESP_LOGD(TAG, "X=%u Y=%u", data->point.x, data->point.y);
     return false;
 }


### PR DESCRIPTION
* Swapping the axes before inverting them subtracts from the wrong maximum value.

* New Kconfig defaults make things more generic and less of a surprise