### PR TITLE
disp_spi.c: Now works with v7 and v8

### DIFF
--- a/lvgl_tft/disp_spi.c
+++ b/lvgl_tft/disp_spi.c
@@ -310,7 +310,12 @@ static void IRAM_ATTR spi_ready(spi_transaction_t *trans)
         disp = lv_refr_get_disp_refreshing();
 #endif
 
+#if LVGL_VERSION_MAJOR < 8
+        lv_disp_flush_ready(&disp->driver);
+#else
         lv_disp_flush_ready(disp->driver);
+#endif
+
     }
 
     if (chained_post_cb) {


### PR DESCRIPTION
Makes the change from #83 dependent on major version number so things work with v7 and v8. Spinoff from discussion towards end of #70.