### PR TITLE
Remove remaining IDF_TARGET-dependent GPIO ranges.

### DIFF
--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -742,10 +742,6 @@ menu "LVGL TFT Display controller"
 
         config LV_DISP_SPI_MOSI
             int "GPIO for MOSI (Master Out Slave In)" if LV_TFT_DISPLAY_PROTOCOL_SPI
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 23 if LV_PREDEFINED_DISPLAY_WROVER4
             default 23 if LV_PREDEFINED_DISPLAY_ATAG
             default 23 if LV_PREDEFINED_DISPLAY_M5STACK || LV_PREDEFINED_DISPLAY_M5STICK
@@ -757,7 +753,6 @@ menu "LVGL TFT Display controller"
             default 19 if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
             default 13 if LV_PREDEFINED_DISPLAY_WT32_SC01
             default 13
-
             help
                 Configure the display MOSI pin here.
 
@@ -772,10 +767,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_SPI_MISO
             int "GPIO for MISO (Master In Slave Out)" if LV_TFT_DISPLAY_PROTOCOL_SPI
             depends on LV_DISPLAY_USE_SPI_MISO
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 19 if LV_PREDEFINED_PINS_TKOALA
             default 38 if LV_PREDEFINED_DISPLAY_M5CORE2
             default 0
@@ -795,10 +786,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_SPI_IO2
             int "GPIO for Quad SPI IO2/WP" if LV_TFT_DISPLAY_PROTOCOL_SPI
             depends on LV_TFT_DISPLAY_SPI_TRANS_MODE_QIO
-            range -1 39 if IDF_TARGET_ESP32
-            range -1 43 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 22 if LV_PREDEFINED_PINS_TKOALA && LV_TFT_DISPLAY_SPI_TRANS_MODE_QIO
             default -1
             help
@@ -807,10 +794,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_SPI_IO3
             int "GPIO for Quad SPI IO3/HD" if LV_TFT_DISPLAY_PROTOCOL_SPI
             depends on LV_TFT_DISPLAY_SPI_TRANS_MODE_QIO
-            range -1 39 if IDF_TARGET_ESP32
-            range -1 43 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 21 if LV_PREDEFINED_PINS_TKOALA && LV_TFT_DISPLAY_SPI_TRANS_MODE_QIO
             default -1
             help
@@ -818,10 +801,6 @@ menu "LVGL TFT Display controller"
 
         config LV_DISP_SPI_CLK
             int "GPIO for CLK (SCK / Serial Clock)" if LV_TFT_DISPLAY_PROTOCOL_SPI
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 18 if LV_PREDEFINED_DISPLAY_M5STACK || LV_PREDEFINED_DISPLAY_M5STICK
             default 18 if LV_PREDEFINED_DISPLAY_M5CORE2
             default 13 if LV_PREDEFINED_DISPLAY_M5STICKC
@@ -847,10 +826,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_SPI_CS
             int "GPIO for CS (Slave Select)" if LV_TFT_DISPLAY_PROTOCOL_SPI
             depends on LV_DISPLAY_USE_SPI_CS
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 5 if LV_PREDEFINED_PINS_38V1
             default 14 if LV_PREDEFINED_DISPLAY_M5STACK || LV_PREDEFINED_DISPLAY_M5STICK
             default 5 if LV_PREDEFINED_DISPLAY_M5CORE2
@@ -876,10 +851,6 @@ menu "LVGL TFT Display controller"
 
         config LV_DISP_PIN_DC
             int "GPIO for DC (Data / Command)" if LV_TFT_DISPLAY_PROTOCOL_SPI
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             depends on LV_DISPLAY_USE_DC
             default 19 if LV_PREDEFINED_PINS_38V1
             default 17 if LV_PREDEFINED_PINS_38V4
@@ -914,10 +885,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_PIN_RST
             int "GPIO for Reset" if LV_TFT_DISPLAY_PROTOCOL_SPI && !LV_DISP_ST7789_SOFT_RESET
             depends on LV_DISP_USE_RST
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 18 if LV_PREDEFINED_PINS_38V1
             default 25 if LV_PREDEFINED_PINS_38V4
             default 33 if LV_PREDEFINED_DISPLAY_M5STACK || LV_PREDEFINED_DISPLAY_M5STICK
@@ -936,10 +903,6 @@ menu "LVGL TFT Display controller"
 
         config LV_DISP_PIN_BUSY
             int "GPIO for Busy" if LV_TFT_DISPLAY_CONTROLLER_IL3820 || LV_TFT_DISPLAY_CONTROLLER_JD79653A || LV_TFT_DISPLAY_CONTROLLER_UC8151D
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 35 if LV_TFT_DISPLAY_CONTROLLER_IL3820 || LV_TFT_DISPLAY_CONTROLLER_JD79653A || LV_TFT_DISPLAY_CONTROLLER_UC8151D
             default 35 if IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2
             default 21 if IDF_TARGET_ESP32C3
@@ -977,10 +940,6 @@ menu "LVGL TFT Display controller"
         config LV_DISP_PIN_BCKL
             int "GPIO for Backlight Control"
             depends on LV_ENABLE_BACKLIGHT_CONTROL
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-
             default 23 if LV_PREDEFINED_PINS_38V1
             default 26 if LV_PREDEFINED_PINS_38V4
             default 32 if LV_PREDEFINED_DISPLAY_M5STACK

--- a/lvgl_touch/Kconfig
+++ b/lvgl_touch/Kconfig
@@ -86,9 +86,6 @@ menu "LVGL Touch controller"
         config LV_TOUCH_SPI_MISO
             int
             prompt "GPIO for MISO (Master In Slave Out)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
             
             default 35 if LV_PREDEFINED_PINS_38V1
             default 19
@@ -98,9 +95,6 @@ menu "LVGL Touch controller"
         config LV_TOUCH_SPI_MOSI
             int
             prompt "GPIO for MOSI (Master Out Slave In)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
 
             default 32 if LV_PREDEFINED_PINS_38V1
             default 23
@@ -109,9 +103,6 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_SPI_CLK
             int "GPIO for CLK (SCK / Serial Clock)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
             
             default 26 if LV_PREDEFINED_PINS_38V1
             default 18
@@ -120,8 +111,6 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_SPI_CS
             int "GPIO for CS (Slave Select)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
 
             default 33 if LV_PREDEFINED_PINS_38V1
             default 5
@@ -130,9 +119,6 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_PIN_IRQ
             int "GPIO for IRQ (Interrupt Request)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
 	    
             default 27 if LV_PREDEFINED_PINS_38V4
             default 25
@@ -223,9 +209,6 @@ menu "LVGL Touch controller"
         config LV_TOUCH_SPI_MISO
             int
             prompt "GPIO for MISO (Master In Slave Out)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
             
             default 35 if LV_PREDEFINED_PINS_38V1
             default 19 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
@@ -238,9 +221,6 @@ menu "LVGL Touch controller"
             # TODO Fix default for ESP32C3
             int
             prompt "GPIO for MOSI (Master Out Slave In)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
 
             default 32 if LV_PREDEFINED_PINS_38V1
             default 18 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
@@ -251,9 +231,6 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_SPI_CLK
             int "GPIO for CLK (SCK / Serial Clock)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
 
             default 26 if LV_PREDEFINED_PINS_38V1
             default 5 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
@@ -263,10 +240,6 @@ menu "LVGL Touch controller"
 
         config LV_TOUCH_SPI_CS
             int "GPIO for CS (Slave Select)"
-            range 0 39 if IDF_TARGET_ESP32
-            range 0 46 if IDF_TARGET_ESP32S2
-            range 0 21 if IDF_TARGET_ESP32C3
-            
             default 33 if LV_PREDEFINED_PINS_38V1
             default 32 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
             default 5


### PR DESCRIPTION
This removes the remaining chip architecture dependent GPIO pin ranges from the Kconfig files.

See discussion in #70