### PR TITLE
LCD backlight controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ if(ESP_PLATFORM)
 file(GLOB SOURCES *.c)
 set(LVGL_INCLUDE_DIRS . lvgl_tft)
 list(APPEND SOURCES "lvgl_tft/disp_driver.c")
-
-#@todo add SimleInclude macro here
+list(APPEND SOURCES "lvgl_tft/esp_lcd_backlight.c")
 
 # Include only the source file of the selected
 # display controller.
@@ -77,11 +76,6 @@ if(CONFIG_LV_TOUCH_CONTROLLER)
     if(CONFIG_LV_TOUCH_DRIVER_PROTOCOL_SPI)
         list(APPEND SOURCES "lvgl_touch/tp_spi.c")
     endif()
-endif()
-
-# Add backlight control to compilation only if it is selected in menuconfig
-if(CONFIG_LV_ENABLE_BACKLIGHT_CONTROL)
-    list(APPEND SOURCES "lvgl_tft/esp_lcd_backlight.c")
 endif()
 
 if(CONFIG_LV_I2C)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ For a ready to use ESP32 project take look at the [lv_port_esp32](https://github
 - [Supported indev controllers](#supported-indev-controllers)
 - [Support for predefined development kits](#support-for-predefined-development-kits)
 - [Thread-safe I2C with I2C Manager](#thread-safe-i2c-with-i2c-manager)
+- [Backlight control](#backlight-control)
 
 **NOTE:** You need to set the display horizontal and vertical size, color depth and
 swap of RGB565 color on the LVGL configuration menuconfig (it's not handled automatically).
@@ -79,3 +80,14 @@ talk to devices on the I2C ports without getting in each other's way. These driv
 use a built-in copy of I2C Manager to talk to the I2C port, but you can also use 
 the I2C Manager component itself and have others play nice with LVGL and vice-versa.
 [Click here](i2c_manager/README.md) for details.
+
+
+## Backlight control
+
+Control of LCD's backlight is provided by separate module that is independent from the display driver.
+Configuration of the backlight controller can be found in menuconfig `LVGL ESP Drivers -> LVGL TFT Display controller`.
+
+There are three modes of operation:
+1. Off - No backlight control
+2. Switch - Allows ON/OFF control
+3. PWM - Allows brightness control (by Pulse-Width-Modulated signal)

--- a/lvgl_tft/GC9A01.c
+++ b/lvgl_tft/GC9A01.c
@@ -111,31 +111,14 @@ void GC9A01_init(void)
 
 	};
 
-#if GC9A01_BCKL == 15
-	gpio_config_t io_conf;
-    io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pin_bit_mask = GPIO_SEL_15;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    gpio_config(&io_conf);
-#endif
-
 	//Initialize non-SPI GPIOs
-        gpio_pad_select_gpio(GC9A01_DC);
+    gpio_pad_select_gpio(GC9A01_DC);
 	gpio_set_direction(GC9A01_DC, GPIO_MODE_OUTPUT);
 
 #if GC9A01_USE_RST
-        gpio_pad_select_gpio(GC9A01_RST);
+    gpio_pad_select_gpio(GC9A01_RST);
 	gpio_set_direction(GC9A01_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if GC9A01_ENABLE_BACKLIGHT_CONTROL
-    gpio_pad_select_gpio(GC9A01_BCKL);
-    gpio_set_direction(GC9A01_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if GC9A01_USE_RST
 	//Reset the display
 	gpio_set_level(GC9A01_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -155,8 +138,6 @@ void GC9A01_init(void)
 		}
 		cmd++;
 	}
-
-	GC9A01_enable_backlight(true);
 
 	GC9A01_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 
@@ -195,22 +176,6 @@ void GC9A01_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * colo
 	uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
 
 	GC9A01_send_color((void*)color_map, size * 2);
-}
-
-void GC9A01_enable_backlight(bool backlight)
-{
-#if GC9A01_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (GC9A01_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(GC9A01_BCKL, tmp);
-#endif
 }
 
 void GC9A01_sleep_in()

--- a/lvgl_tft/GC9A01.h
+++ b/lvgl_tft/GC9A01.h
@@ -25,19 +25,9 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
-#define GC9A01_DC       CONFIG_LV_DISP_PIN_DC
-#define GC9A01_RST      CONFIG_LV_DISP_PIN_RST
-#define GC9A01_USE_RST  CONFIG_LV_DISP_USE_RST
-#define GC9A01_BCKL     CONFIG_LV_DISP_PIN_BCKL
-
-#define GC9A01_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define GC9A01_BCKL_ACTIVE_LVL 1
-#else
-  #define GC9A01_BCKL_ACTIVE_LVL 0
-#endif
-
+#define GC9A01_DC            CONFIG_LV_DISP_PIN_DC
+#define GC9A01_RST           CONFIG_LV_DISP_PIN_RST
+#define GC9A01_USE_RST       CONFIG_LV_DISP_USE_RST
 #define GC9A01_INVERT_COLORS CONFIG_LV_INVERT_COLORS
 
 /**********************
@@ -50,7 +40,6 @@ extern "C" {
 
 void GC9A01_init(void);
 void GC9A01_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void GC9A01_enable_backlight(bool backlight);
 void GC9A01_sleep_in(void);
 void GC9A01_sleep_out(void);
 

--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -910,51 +910,6 @@ menu "LVGL TFT Display controller"
             help
                 Configure the display Busy pin here.
 
-        config LV_ENABLE_BACKLIGHT_CONTROL
-            bool "Enable control of the display backlight by using an GPIO." if \
-                ( LV_PREDEFINED_DISPLAY_NONE && ! ( LV_TFT_DISPLAY_CONTROLLER_SH1107 || LV_TFT_DISPLAY_CONTROLLER_SSD1306 ) ) \
-                || LV_PREDEFINED_DISPLAY_RPI_MPI3501
-            default y if LV_PREDEFINED_DISPLAY_M5STACK
-            default n if LV_PREDEFINED_DISPLAY_M5CORE2
-            default y if LV_PREDEFINED_DISPLAY_WROVER4
-            default y if LV_PREDEFINED_DISPLAY_ERTFT0356
-            default y if LV_PREDEFINED_DISPLAY_TTGO
-            default y if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
-            default y if LV_PREDEFINED_DISPLAY_WT32_SC01
-            help
-                Enable controlling the display backlight using an GPIO
-
-        config LV_BACKLIGHT_ACTIVE_LVL
-            bool "Is backlight turn on with a HIGH (1) logic level?"
-            depends on LV_ENABLE_BACKLIGHT_CONTROL
-            default y if LV_PREDEFINED_DISPLAY_M5STACK
-            default y if LV_PREDEFINED_DISPLAY_ERTFT0356
-            default y if LV_PREDEFINED_DISPLAY_TTGO
-            default y if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
-            default y if LV_PREDEFINED_DISPLAY_WT32_SC01
-            help
-                Some backlights are turned on with a high signal, others held low.
-                If enabled, a value of 1 will be sent to the display to enable the backlight,
-                otherwise a 0 will be expected to enable it.
-
-        config LV_DISP_PIN_BCKL
-            int "GPIO for Backlight Control"
-            depends on LV_ENABLE_BACKLIGHT_CONTROL
-            default 23 if LV_PREDEFINED_PINS_38V1
-            default 26 if LV_PREDEFINED_PINS_38V4
-            default 32 if LV_PREDEFINED_DISPLAY_M5STACK
-            default 5 if LV_PREDEFINED_DISPLAY_WROVER4
-            default 2 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
-            default 27 if LV_PREDEFINED_DISPLAY_ERTFT0356
-            default 0  if LV_PREDEFINED_PINS_TKOALA
-            default 4 if LV_PREDEFINED_DISPLAY_TTGO
-            default 2 if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
-            default 23 if LV_PREDEFINED_DISPLAY_WT32_SC01
-            default 27
-
-            help
-                Configure the display BCLK (LED) pin here.
-
     endmenu
 
     choice
@@ -965,18 +920,85 @@ menu "LVGL TFT Display controller"
         config LV_I2C_DISPLAY_PORT_0
             bool
             prompt "I2C port 0"
-            help 
+            help
                 I2C is shared peripheral managed by I2C Manager. In order to configure I2C Manager (pinout, etc.) see menu
                 Component config->I2C Port Settings.
 
         config LV_I2C_DISPLAY_PORT_1
             bool
             prompt "I2C port 1"
-            help 
+            help
                 I2C is shared peripheral managed by I2C Manager. In order to configure I2C Manager (pinout, etc.) see menu
                 Component config->I2C Port Settings.
 
     endchoice
+
+    choice
+        prompt "Backlight Control" if \
+            (! ( LV_TFT_DISPLAY_CONTROLLER_SH1107 || LV_TFT_DISPLAY_CONTROLLER_SSD1306 ) )
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_M5STACK
+        default LV_DISP_BACKLIGHT_OFF if LV_PREDEFINED_DISPLAY_M5CORE2
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_WROVER4
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_ERTFT0356
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_TTGO
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
+        default LV_DISP_BACKLIGHT_SWITCH if LV_PREDEFINED_DISPLAY_WT32_SC01
+        default LV_DISP_BACKLIGHT_OFF
+
+        config LV_DISP_BACKLIGHT_OFF
+            bool
+            prompt "Not Used"
+            help
+                Display backlight is not controlled by this driver, must be hardwired in hardware.
+
+        config LV_DISP_BACKLIGHT_SWITCH
+            bool
+            prompt "Switch control"
+            help
+                Display backlight can be switched on or off.
+
+        config LV_DISP_BACKLIGHT_PWM
+            bool
+            prompt "PWM control"
+            help
+                Display backlight is controlled by pulse-width modulation, allowing brightness settings.
+
+    endchoice
+
+    config LV_BACKLIGHT_ACTIVE_LVL
+        bool "Is backlight turn on with a HIGH (1) logic level?" if \
+            ( LV_PREDEFINED_DISPLAY_NONE && ! ( LV_TFT_DISPLAY_CONTROLLER_SH1107 || LV_TFT_DISPLAY_CONTROLLER_SSD1306 ) ) \
+            || LV_PREDEFINED_DISPLAY_RPI_MPI3501
+        depends on !LV_DISP_BACKLIGHT_OFF
+        default y if LV_PREDEFINED_DISPLAY_M5STACK
+        default y if LV_PREDEFINED_DISPLAY_ERTFT0356
+        default y if LV_PREDEFINED_DISPLAY_TTGO
+        default y if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
+        default y if LV_PREDEFINED_DISPLAY_WT32_SC01
+        help
+            Some backlights are turned on with a high signal, others held low.
+            If enabled, a value of 1 will be sent to the display to enable the backlight,
+            otherwise a 0 will be expected to enable it.
+
+    config LV_DISP_PIN_BCKL
+        int "GPIO for Backlight Control" if \
+            ( LV_PREDEFINED_DISPLAY_NONE && ! ( LV_TFT_DISPLAY_CONTROLLER_SH1107 || LV_TFT_DISPLAY_CONTROLLER_SSD1306 ) ) \
+            || LV_PREDEFINED_DISPLAY_RPI_MPI3501
+        depends on !LV_DISP_BACKLIGHT_OFF
+        default 23 if LV_PREDEFINED_PINS_38V1
+        default 26 if LV_PREDEFINED_PINS_38V4
+        default 32 if LV_PREDEFINED_DISPLAY_M5STACK
+        default 5 if LV_PREDEFINED_DISPLAY_WROVER4
+        default 2 if LV_PREDEFINED_DISPLAY_ADA_FEATHERWING
+        default 27 if LV_PREDEFINED_DISPLAY_ERTFT0356
+        default 0  if LV_PREDEFINED_PINS_TKOALA
+        default 4 if LV_PREDEFINED_DISPLAY_TTGO
+        default 2 if LV_PREDEFINED_DISPLAY_TTGO_CAMERA_PLUS
+        default 23 if LV_PREDEFINED_DISPLAY_WT32_SC01
+        default 27
+
+        help
+            Configure the display BCLK (LED) pin here.
 
     config LV_I2C
         bool

--- a/lvgl_tft/disp_driver.h
+++ b/lvgl_tft/disp_driver.h
@@ -67,7 +67,7 @@ extern "C" {
  **********************/
 
 /* Initialize display */
-void disp_driver_init(void);
+void *disp_driver_init(void);
 
 /* Display flush callback */
 void disp_driver_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);

--- a/lvgl_tft/esp_lcd_backlight.c
+++ b/lvgl_tft/esp_lcd_backlight.c
@@ -10,7 +10,8 @@
 #include "driver/ledc.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
-#include "esp_rom_gpio.h" // for output signal inversion
+#include "esp_rom_gpio.h"    // for output signal inversion
+#include "soc/ledc_periph.h" // to invert LEDC output on IDF version < v4.3
 
 typedef struct {
     bool pwm_control; // true: LEDC is used, false: GPIO is used
@@ -40,8 +41,7 @@ disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
             .intr_type = LEDC_INTR_DISABLE,
             .timer_sel = config->timer_idx,
             .duty = 0,
-            .hpoint = 0,
-            .flags.output_invert = config->output_invert //@todo added only in recent IDF versions
+            .hpoint = 0
         };
         const ledc_timer_config_t LCD_backlight_timer = {
             .speed_mode = LEDC_LOW_SPEED_MODE,
@@ -52,6 +52,7 @@ disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
 
         ESP_ERROR_CHECK(ledc_timer_config(&LCD_backlight_timer));
         ESP_ERROR_CHECK(ledc_channel_config(&LCD_backlight_channel));
+        esp_rom_gpio_connect_out_signal(config->gpio_num, ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx, config->output_invert, 0);
     }
     else
     {

--- a/lvgl_tft/esp_lcd_backlight.c
+++ b/lvgl_tft/esp_lcd_backlight.c
@@ -8,51 +8,95 @@
  *********************/
 #include "esp_lcd_backlight.h"
 #include "driver/ledc.h"
+#include "driver/gpio.h"
 #include "esp_log.h"
+#include "esp_rom_gpio.h" // for output signal inversion
 
-static const char *TAG = "disp_brightness";
+typedef struct {
+    bool pwm_control; // true: LEDC is used, false: GPIO is used
+    int index;        // Either GPIO or LEDC channel
+} disp_backlight_t;
 
-void disp_brightness_control_enable(void)
+static const char *TAG = "disp_backlight";
+
+disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
 {
-	/*
-		Configure LED (Backlight) pin as PWM for Brightness control.
-	*/
-    ledc_channel_config_t LCD_backlight_channel = {
-        .gpio_num = DISP_PIN_BCKL,
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .channel = LEDC_CHANNEL_0,
-        .intr_type = LEDC_INTR_DISABLE,
-        .timer_sel = LEDC_TIMER_0,
-        .duty = 0,
-        .hpoint = 0,
-        .flags.output_invert = 0
-    };
-    ledc_timer_config_t LCD_backlight_timer = {
-        .speed_mode = LEDC_LOW_SPEED_MODE,
-        .bit_num = LEDC_TIMER_10_BIT,
-        .timer_num = LEDC_TIMER_0,
-        .freq_hz = 5000,
-        .clk_cfg = LEDC_AUTO_CLK
-    };
+    if (config == NULL)
+        return NULL;
+    disp_backlight_t *bckl_dev = calloc(1, sizeof(disp_backlight_t));
+    if (bckl_dev == NULL){
+        ESP_LOGW(TAG, "Could not create new LCD backlight instance");
+        return NULL;
+    }
 
-	ESP_ERROR_CHECK( ledc_timer_config(&LCD_backlight_timer) );
-	ESP_ERROR_CHECK( ledc_channel_config(&LCD_backlight_channel) );
+    if (config->pwm_control){
+        // Configure LED (Backlight) pin as PWM for Brightness control.
+        bckl_dev->pwm_control = true;
+        bckl_dev->index = config->channel_idx;
+        const ledc_channel_config_t LCD_backlight_channel = {
+            .gpio_num = config->gpio_num,
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .channel = config->channel_idx,
+            .intr_type = LEDC_INTR_DISABLE,
+            .timer_sel = config->timer_idx,
+            .duty = 0,
+            .hpoint = 0,
+            .flags.output_invert = config->output_invert //@todo added only in recent IDF versions
+        };
+        const ledc_timer_config_t LCD_backlight_timer = {
+            .speed_mode = LEDC_LOW_SPEED_MODE,
+            .bit_num = LEDC_TIMER_10_BIT,
+            .timer_num = config->timer_idx,
+            .freq_hz = 5000,
+            .clk_cfg = LEDC_AUTO_CLK};
 
+        ESP_ERROR_CHECK(ledc_timer_config(&LCD_backlight_timer));
+        ESP_ERROR_CHECK(ledc_channel_config(&LCD_backlight_channel));
+    }
+    else
+    {
+        // Configure GPIO for output
+        bckl_dev->index = config->gpio_num;
+        gpio_pad_select_gpio(config->gpio_num);
+        ESP_ERROR_CHECK(gpio_set_direction(config->gpio_num, GPIO_MODE_OUTPUT));
+        esp_rom_gpio_connect_out_signal(config->gpio_num, SIG_GPIO_OUT_IDX, config->output_invert, false);
+    }
+
+    return (disp_backlight_h)bckl_dev;
 }
 
-void disp_set_brightness(uint16_t brightness)
+void disp_backlight_set(disp_backlight_h bckl, int brightness_percent)
 {
-	/*
-		Set brightness.
-		0   -> Display off
-		100 -> Full brightness
-		NOTE: brightness value must be between 0 - 100
-	*/
-	if(brightness > 100)
-	{
-		ESP_LOGE(TAG, "Brightness value must be between 0 - 100");
-		return;
-	}
-    ESP_ERROR_CHECK( ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, brightness*10) );
-	ESP_ERROR_CHECK( ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0) );
+    // Check input paramters
+    if (bckl == NULL)
+        return;
+    if (brightness_percent > 100)
+        brightness_percent = 100;
+    if (brightness_percent < 0)
+        brightness_percent = 0;
+
+    disp_backlight_t *bckl_dev = (disp_backlight_t *) bckl;
+    ESP_LOGI(TAG, "Setting LCD backlight: %d%%", brightness_percent);
+
+    if (bckl_dev->pwm_control) {
+        uint32_t duty_cycle = (1023 * brightness_percent) / 100; // LEDC resolution set to 10bits, thus: 100% = 1023
+        ESP_ERROR_CHECK(ledc_set_duty(LEDC_LOW_SPEED_MODE, bckl_dev->index, duty_cycle));
+        ESP_ERROR_CHECK(ledc_update_duty(LEDC_LOW_SPEED_MODE, bckl_dev->index));
+    } else {
+        ESP_ERROR_CHECK(gpio_set_level(bckl_dev->index, brightness_percent));
+    }
+}
+
+void disp_backlight_delete(disp_backlight_h bckl)
+{
+    if (bckl == NULL)
+        return;
+
+    disp_backlight_t *bckl_dev = (disp_backlight_t *) bckl;
+    if (bckl_dev->pwm_control) {
+        ledc_stop(LEDC_LOW_SPEED_MODE, bckl_dev->index, 0);
+    } else {
+        gpio_reset_pin(bckl_dev->index);
+    }
+    free (bckl);
 }

--- a/lvgl_tft/esp_lcd_backlight.h
+++ b/lvgl_tft/esp_lcd_backlight.h
@@ -27,6 +27,7 @@ typedef void * disp_backlight_h;
 /**
  * @brief Configuration structure of backlight controller
  *
+ * Must be passed to disp_backlight_new() for correct configuration
  */
 typedef struct {
     bool pwm_control;
@@ -35,7 +36,7 @@ typedef struct {
 
     // Relevant only for PWM controlled backlight
     // Ignored for switch (ON/OFF) backlight control
-    int timer_idx; // ledc_timer_t
+    int timer_idx;   // ledc_timer_t
     int channel_idx; // ledc_channel_t
 } disp_backlight_config_t;
 

--- a/lvgl_tft/esp_lcd_backlight.h
+++ b/lvgl_tft/esp_lcd_backlight.h
@@ -9,26 +9,55 @@
  *      INCLUDES
  *********************/
 #include <stdbool.h>
-#ifdef LV_LVGL_H_INCLUDE_SIMPLE
-#include "lvgl.h"
-#else
-#include "lvgl/lvgl.h"
-#endif
 
-
-/*********************
- *      DEFINES
- *********************/
-#if CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-#define DISP_PIN_BCKL   CONFIG_LV_DISP_PIN_BCKL
+#ifdef __cplusplus
+extern "C" { /* extern "C" */
 #endif
 
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-void disp_brightness_control_enable(void);
-void disp_set_brightness(uint16_t brightness);
 
+/**
+ * @brief Display backlight controller handle
+ *
+ */
+typedef void * disp_backlight_h;
+
+/**
+ * @brief Configuration structure of backlight controller
+ *
+ */
+typedef struct {
+    bool pwm_control;
+    bool output_invert;
+    int gpio_num; // see gpio_num_t
+
+    // Relevant only for PWM controlled backlight
+    // Ignored for switch (ON/OFF) backlight control
+    int timer_idx; // ledc_timer_t
+    int channel_idx; // ledc_channel_t
+} disp_backlight_config_t;
+
+/**
+ * @brief Create new backlight controller
+ *
+ * @param[in] config Configuration structure of backlight controller
+ * @return           Display backlight controller handle
+ */
+disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config);
+
+/**
+ * @brief Set backlight
+ *
+ * Brightness parameter can be 0-100 for PWM controlled backlight.
+ * GPIO controlled backlight (ON/OFF) is turned off witch value 0 and turned on with any positive value.
+ *
+ * @param bckl                   Backlight controller handle
+ * @param[in] brightness_percent Brightness in [%]
+ */
+void disp_backlight_set(disp_backlight_h bckl, int brightness_percent);
+void disp_backlight_delete(disp_backlight_h bckl);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -160,20 +160,13 @@ static uint8_t displayType = HX8357D;
 void hx8357_init(void)
 {
 	//Initialize non-SPI GPIOs
-        gpio_pad_select_gpio(HX8357_DC);
+    gpio_pad_select_gpio(HX8357_DC);
 	gpio_set_direction(HX8357_DC, GPIO_MODE_OUTPUT);
 
 #if HX8357_USE_RST
-        gpio_pad_select_gpio(HX8357_RST);
+    gpio_pad_select_gpio(HX8357_RST);
 	gpio_set_direction(HX8357_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if HX8357_ENABLE_BACKLIGHT_CONTROL
-        gpio_pad_select_gpio(HX8357_BCKL);
-	gpio_set_direction(HX8357_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if HX8357_USE_RST
 	//Reset the display
 	gpio_set_level(HX8357_RST, 0);
 	vTaskDelay(10 / portTICK_RATE_MS);
@@ -210,8 +203,6 @@ void hx8357_init(void)
 #else
     hx8357_send_cmd(HX8357_INVOFF);
 #endif
-
-	hx8357_enable_backlight(true);
 }
 
 
@@ -247,23 +238,6 @@ void hx8357_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * colo
 	hx8357_send_cmd(HX8357_RAMWR);
 	hx8357_send_color((void*)color_map, size * 2);
 }
-
-void hx8357_enable_backlight(bool backlight)
-{
-#if HX8357_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGD(TAG, "%s backlight.\n", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (HX8357_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(HX8357_BCKL, tmp);
-#endif
-}
-
 
 void hx8357_set_rotation(uint8_t r)
 {

--- a/lvgl_tft/hx8357.h
+++ b/lvgl_tft/hx8357.h
@@ -35,19 +35,10 @@ extern "C" {
  /*********************
  *      DEFINES
  *********************/
-#define HX8357_DC       CONFIG_LV_DISP_PIN_DC
-#define HX8357_RST      CONFIG_LV_DISP_PIN_RST
-#define HX8357_USE_RST  CONFIG_LV_DISP_USE_RST
-#define HX8357_BCKL     CONFIG_LV_DISP_PIN_BCKL
-
-#define HX8357_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-#define HX8357_INVERT_COLORS            CONFIG_LV_INVERT_COLORS
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define HX8357_BCKL_ACTIVE_LVL 1
-#else
-  #define HX8357_BCKL_ACTIVE_LVL 0
-#endif
+#define HX8357_DC             CONFIG_LV_DISP_PIN_DC
+#define HX8357_RST            CONFIG_LV_DISP_PIN_RST
+#define HX8357_USE_RST        CONFIG_LV_DISP_USE_RST
+#define HX8357_INVERT_COLORS  CONFIG_LV_INVERT_COLORS
 
 
 /*******************
@@ -136,7 +127,6 @@ extern "C" {
 
 void hx8357_init(void);
 void hx8357_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void hx8357_enable_backlight(bool backlight);
 void hx8357_set_rotation(uint8_t r);
 
 /**********************

--- a/lvgl_tft/il3820.c
+++ b/lvgl_tft/il3820.c
@@ -199,15 +199,13 @@ void il3820_init(void)
     gpio_pad_select_gpio(IL3820_DC_PIN);
     gpio_set_direction(IL3820_DC_PIN, GPIO_MODE_OUTPUT);
 
-#if IL3820_USE_RST
-    gpio_pad_select_gpio(IL3820_RST_PIN);
-    gpio_set_direction(IL3820_RST_PIN, GPIO_MODE_OUTPUT);
-#endif
-
     gpio_pad_select_gpio(IL3820_BUSY_PIN);
     gpio_set_direction(IL3820_BUSY_PIN,  GPIO_MODE_INPUT);
 
 #if IL3820_USE_RST
+    gpio_pad_select_gpio(IL3820_RST_PIN);
+    gpio_set_direction(IL3820_RST_PIN, GPIO_MODE_OUTPUT);
+
     /* Harware reset */
     gpio_set_level( IL3820_RST_PIN, 0);
     vTaskDelay(IL3820_RESET_DELAY / portTICK_RATE_MS);

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -143,10 +143,6 @@ void ili9163c_init(void)
 	gpio_pad_select_gpio(ILI9163C_RST);
 	gpio_set_direction(ILI9163C_RST, GPIO_MODE_OUTPUT);
 
-#if ILI9163C_ENABLE_BACKLIGHT_CONTROL
-	gpio_pad_select_gpio(ILI9163C_BCKL);
-	gpio_set_direction(ILI9163C_BCKL, GPIO_MODE_OUTPUT);
-#endif
 	//Reset the display
 	gpio_set_level(ILI9163C_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -165,8 +161,6 @@ void ili9163c_init(void)
 		}
 		cmd++;
 	}
-
-	ili9163c_enable_backlight(true);
 
 	ili9163c_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 }
@@ -197,22 +191,6 @@ void ili9163c_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color
 	uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
 
 	ili9163c_send_color((void *)color_map, size * 2);
-}
-
-void ili9163c_enable_backlight(bool backlight)
-{
-#if ILI9163C_ENABLE_BACKLIGHT_CONTROL
-	ESP_LOGD(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-	uint32_t tmp = 0;
-
-#if (ILI9163C_BCKL_ACTIVE_LVL == 1)
-	tmp = backlight ? 1 : 0;
-#else
-	tmp = backlight ? 0 : 1;
-#endif
-
-	gpio_set_level(ILI9163C_BCKL, tmp);
-#endif
 }
 
 void ili9163c_sleep_in()

--- a/lvgl_tft/ili9163c.h
+++ b/lvgl_tft/ili9163c.h
@@ -26,35 +26,24 @@ extern "C"
 /*********************
  *      DEFINES
  *********************/
-#define ILI9163C_DC CONFIG_LV_DISP_PIN_DC
-#define ILI9163C_RST CONFIG_LV_DISP_PIN_RST
-#define ILI9163C_BCKL CONFIG_LV_DISP_PIN_BCKL
-
-#define ILI9163C_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-#define ILI9163C_BCKL_ACTIVE_LVL 1
-#else
-#define ILI9163C_BCKL_ACTIVE_LVL 0
-#endif
-
+#define ILI9163C_DC            CONFIG_LV_DISP_PIN_DC
+#define ILI9163C_RST           CONFIG_LV_DISP_PIN_RST
 #define ILI9163C_INVERT_COLORS CONFIG_LV_INVERT_COLORS
 
-  /**********************
+/**********************
  *      TYPEDEFS
  **********************/
 
-  /**********************
+/**********************
  * GLOBAL PROTOTYPES
  **********************/
 
-  void ili9163c_init(void);
-  void ili9163c_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
-  void ili9163c_enable_backlight(bool backlight);
-  void ili9163c_sleep_in(void);
-  void ili9163c_sleep_out(void);
+void ili9163c_init(void);
+void ili9163c_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
+void ili9163c_sleep_in(void);
+void ili9163c_sleep_out(void);
 
-  /**********************
+/**********************
  *      MACROS
  **********************/
 

--- a/lvgl_tft/ili9341.c
+++ b/lvgl_tft/ili9341.c
@@ -80,30 +80,14 @@ void ili9341_init(void)
 		{0, {0}, 0xff},
 	};
 
-#if ILI9341_BCKL == 15
-	gpio_config_t io_conf;
-    io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pin_bit_mask = GPIO_SEL_15;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    gpio_config(&io_conf);
-#endif
-
 	//Initialize non-SPI GPIOs
-        gpio_pad_select_gpio(ILI9341_DC);
+    gpio_pad_select_gpio(ILI9341_DC);
 	gpio_set_direction(ILI9341_DC, GPIO_MODE_OUTPUT);
+
 #if ILI9341_USE_RST
-        gpio_pad_select_gpio(ILI9341_RST);
+    gpio_pad_select_gpio(ILI9341_RST);
 	gpio_set_direction(ILI9341_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if ILI9341_ENABLE_BACKLIGHT_CONTROL
-    gpio_pad_select_gpio(ILI9341_BCKL);
-    gpio_set_direction(ILI9341_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if ILI9341_USE_RST
 	//Reset the display
 	gpio_set_level(ILI9341_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -124,9 +108,7 @@ void ili9341_init(void)
 		cmd++;
 	}
 
-	ili9341_enable_backlight(true);
-
-        ili9341_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
+    ili9341_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 
 #if ILI9341_INVERT_COLORS == 1
 	ili9341_send_cmd(0x21);
@@ -158,27 +140,8 @@ void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 
 	/*Memory write*/
 	ili9341_send_cmd(0x2C);
-
-
 	uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
-
 	ili9341_send_color((void*)color_map, size * 2);
-}
-
-void ili9341_enable_backlight(bool backlight)
-{
-#if ILI9341_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (ILI9341_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(ILI9341_BCKL, tmp);
-#endif
 }
 
 void ili9341_sleep_in()

--- a/lvgl_tft/ili9341.h
+++ b/lvgl_tft/ili9341.h
@@ -29,16 +29,6 @@ extern "C" {
 #define ILI9341_DC        CONFIG_LV_DISP_PIN_DC
 #define ILI9341_USE_RST   CONFIG_LV_DISP_USE_RST
 #define ILI9341_RST       CONFIG_LV_DISP_PIN_RST
-#define ILI9341_BCKL      CONFIG_LV_DISP_PIN_BCKL
-
-#define ILI9341_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define ILI9341_BCKL_ACTIVE_LVL 1
-#else
-  #define ILI9341_BCKL_ACTIVE_LVL 0
-#endif
-
 #define ILI9341_INVERT_COLORS CONFIG_LV_INVERT_COLORS
 
 /**********************
@@ -51,7 +41,6 @@ extern "C" {
 
 void ili9341_init(void);
 void ili9341_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void ili9341_enable_backlight(bool backlight);
 void ili9341_sleep_in(void);
 void ili9341_sleep_out(void);
 

--- a/lvgl_tft/ili9481.c
+++ b/lvgl_tft/ili9481.c
@@ -80,14 +80,7 @@ void ili9481_init(void)
 #if ILI9481_USE_RST
     gpio_pad_select_gpio(ILI9481_RST);
     gpio_set_direction(ILI9481_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if ILI9481_ENABLE_BACKLIGHT_CONTROL
-    gpio_pad_select_gpio(ILI9481_BCKL);
-    gpio_set_direction(ILI9481_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if ILI9481_USE_RST
     //Reset the display
     gpio_set_level(ILI9481_RST, 0);
     vTaskDelay(100 / portTICK_RATE_MS);
@@ -111,8 +104,6 @@ void ili9481_init(void)
         }
         cmd++;
     }
-
-    ili9481_enable_backlight(true);
 
     ili9481_set_orientation(ILI9481_DISPLAY_ORIENTATION);
 }
@@ -171,22 +162,6 @@ void ili9481_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 
     ili9481_send_color((void *) mybuf, size * 3);
     heap_caps_free(mybuf);
-}
-
-void ili9481_enable_backlight(bool backlight)
-{
-#if ILI9481_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (ILI9481_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(ILI9481_BCKL, tmp);
-#endif
 }
 
 /**********************

--- a/lvgl_tft/ili9481.h
+++ b/lvgl_tft/ili9481.h
@@ -25,20 +25,12 @@ extern "C" {
 /*********************
  *      DEFINES
  *********************/
-#define ILI9481_DC        CONFIG_LV_DISP_PIN_DC
-#define ILI9481_RST       CONFIG_LV_DISP_PIN_RST
-#define ILI9481_USE_RST   CONFIG_LV_DISP_USE_RST
-#define ILI9481_BCKL      CONFIG_LV_DISP_PIN_BCKL
-
-#define ILI9481_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-#define ILI9481_INVERT_COLORS CONFIG_LV_INVERT_COLORS
+#define ILI9481_DC                  CONFIG_LV_DISP_PIN_DC
+#define ILI9481_RST                 CONFIG_LV_DISP_PIN_RST
+#define ILI9481_USE_RST             CONFIG_LV_DISP_USE_RST
+#define ILI9481_INVERT_COLORS       CONFIG_LV_INVERT_COLORS
 #define ILI9481_DISPLAY_ORIENTATION CONFIG_LV_DISPLAY_ORIENTATION
 
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define ILI9481_BCKL_ACTIVE_LVL 1
-#else
-  #define ILI9481_BCKL_ACTIVE_LVL 0
-#endif
 
 /*******************
  * ILI9481 REGS
@@ -118,7 +110,6 @@ extern "C" {
 
 void ili9481_init(void);
 void ili9481_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void ili9481_enable_backlight(bool backlight);
 
 /**********************
  *      MACROS

--- a/lvgl_tft/ili9486.c
+++ b/lvgl_tft/ili9486.c
@@ -65,31 +65,14 @@ void ili9486_init(void)
 		{0x00, {0}, 0xff},
 	};
 
-#if ILI9486_BCKL == 15
-    gpio_config_t io_conf;
-    io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pin_bit_mask = GPIO_SEL_15;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    gpio_config(&io_conf);
-#endif
-
 	//Initialize non-SPI GPIOs
-        gpio_pad_select_gpio(ILI9486_DC);
+    gpio_pad_select_gpio(ILI9486_DC);
 	gpio_set_direction(ILI9486_DC, GPIO_MODE_OUTPUT);
 
 #if ILI9486_USE_RST
-        gpio_pad_select_gpio(ILI9486_RST);
+    gpio_pad_select_gpio(ILI9486_RST);
 	gpio_set_direction(ILI9486_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if ILI9486_ENABLE_BACKLIGHT_CONTROL
-    gpio_pad_select_gpio(ILI9486_BCKL);
-    gpio_set_direction(ILI9486_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if ILI9486_USE_RST
 	//Reset the display
 	gpio_set_level(ILI9486_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -110,9 +93,7 @@ void ili9486_init(void)
 		cmd++;
 	}
 
-	ili9486_enable_backlight(true);
-
-        ili9486_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
+    ili9486_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 }
 
 void ili9486_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map)
@@ -142,22 +123,6 @@ void ili9486_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 	size = lv_area_get_width(area) * lv_area_get_height(area);
 
     ili9486_send_color((void*) color_map, size * 2);
-}
-
-void ili9486_enable_backlight(bool backlight)
-{
-#if ILI9486_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (ILI9486_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(ILI9486_BCKL, tmp);
-#endif
 }
 
 /**********************

--- a/lvgl_tft/ili9486.h
+++ b/lvgl_tft/ili9486.h
@@ -28,15 +28,7 @@ extern "C" {
 #define ILI9486_DC      CONFIG_LV_DISP_PIN_DC
 #define ILI9486_RST     CONFIG_LV_DISP_PIN_RST
 #define ILI9486_USE_RST CONFIG_LV_DISP_USE_RST
-#define ILI9486_BCKL    CONFIG_LV_DISP_PIN_BCKL
 
-#define ILI9486_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define ILI9486_BCKL_ACTIVE_LVL 1
-#else
-  #define ILI9486_BCKL_ACTIVE_LVL 0
-#endif
 
 /**********************
  *      TYPEDEFS
@@ -48,7 +40,6 @@ extern "C" {
 
 void ili9486_init(void);
 void ili9486_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void ili9486_enable_backlight(bool backlight);
 
 /**********************
  *      MACROS

--- a/lvgl_tft/ili9488.c
+++ b/lvgl_tft/ili9488.c
@@ -76,20 +76,13 @@ void ili9488_init(void)
 	};
 
 	//Initialize non-SPI GPIOs
-        gpio_pad_select_gpio(ILI9488_DC);
+    gpio_pad_select_gpio(ILI9488_DC);
 	gpio_set_direction(ILI9488_DC, GPIO_MODE_OUTPUT);
 
 #if ILI9488_USE_RST
-        gpio_pad_select_gpio(ILI9488_RST);
+    gpio_pad_select_gpio(ILI9488_RST);
 	gpio_set_direction(ILI9488_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if ILI9488_ENABLE_BACKLIGHT_CONTROL
-        gpio_pad_select_gpio(ILI9488_BCKL);
-	gpio_set_direction(ILI9488_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if ILI9488_USE_RST
 	//Reset the display
 	gpio_set_level(ILI9488_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -114,9 +107,7 @@ void ili9488_init(void)
 		cmd++;
 	}
 
-	ili9488_enable_backlight(true);
-
-        ili9488_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
+    ili9488_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 }
 
 // Flush function based on mvturnho repo
@@ -173,22 +164,6 @@ void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
 
 	ili9488_send_color((void *) mybuf, size * 3);
 	heap_caps_free(mybuf);
-}
-
-void ili9488_enable_backlight(bool backlight)
-{
-#if ILI9488_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (ILI9488_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(ILI9488_BCKL, tmp);
-#endif
 }
 
 /**********************

--- a/lvgl_tft/ili9488.h
+++ b/lvgl_tft/ili9488.h
@@ -27,16 +27,7 @@ extern "C" {
  *********************/
 #define ILI9488_DC      CONFIG_LV_DISP_PIN_DC
 #define ILI9488_RST     CONFIG_LV_DISP_PIN_RST
-#define ILI9488_USE_RST CONFIG_LV_DISP_USE_RST
-#define ILI9488_BCKL    CONFIG_LV_DISP_PIN_BCKL
-
-#define ILI9488_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define ILI9488_BCKL_ACTIVE_LVL 1
-#else
-  #define ILI9488_BCKL_ACTIVE_LVL 0
-#endif
+#define ILI9488_USE_RST CONFIG_LV_DISP_USE_RSTS
 
 /*******************
  * ILI9488 REGS
@@ -155,7 +146,6 @@ typedef struct {
 
 void ili9488_init(void);
 void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void ili9488_enable_backlight(bool backlight);
 
 /**********************
  *      MACROS

--- a/lvgl_tft/ra8875.c
+++ b/lvgl_tft/ra8875.c
@@ -148,29 +148,12 @@ void ra8875_init(void)
 
     ESP_LOGI(TAG, "Initializing RA8875...");
 
-#if (CONFIG_LV_DISP_PIN_BCKL == 15)
-    gpio_config_t io_conf;
-    io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-    io_conf.mode = GPIO_MODE_OUTPUT;
-    io_conf.pin_bit_mask = GPIO_SEL_15;
-    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-    gpio_config(&io_conf);
-#endif
-
     // Initialize non-SPI GPIOs
 
 #if RA8875_USE_RST
     gpio_pad_select_gpio(RA8875_RST);
     gpio_set_direction(RA8875_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#ifdef CONFIG_LV_DISP_PIN_BCKL
-    gpio_pad_select_gpio(CONFIG_LV_DISP_PIN_BCKL);
-    gpio_set_direction(CONFIG_LV_DISP_PIN_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if RA8875_USE_RST
     // Reset the RA8875
     gpio_set_level(RA8875_RST, 0);
     vTaskDelay(DIV_ROUND_UP(100, portTICK_RATE_MS));
@@ -200,28 +183,8 @@ void ra8875_init(void)
         ESP_LOGW(TAG, "WARNING: Memory clear timed out; RA8875 may be unresponsive.");
     }
 
-    // Enable the display and backlight
+    // Enable the display
     ra8875_enable_display(true);
-    ra8875_enable_backlight(true);
-}
-
-void ra8875_enable_backlight(bool backlight)
-{
-#if CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-    ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-    #if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-        tmp = backlight ? 1 : 0;
-    #else
-        tmp = backlight ? 0 : 1;
-    #endif
-
-#ifdef CONFIG_LV_DISP_PIN_BCKL
-    gpio_set_level(CONFIG_LV_DISP_PIN_BCKL, tmp);
-#endif
-
-#endif
 }
 
 void ra8875_enable_display(bool enable)

--- a/lvgl_tft/ra8875.h
+++ b/lvgl_tft/ra8875.h
@@ -97,7 +97,6 @@ extern "C" {
  **********************/
 
 void ra8875_init(void);
-void ra8875_enable_backlight(bool backlight);
 void ra8875_enable_display(bool enable);
 void ra8875_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
 

--- a/lvgl_tft/st7735s.h
+++ b/lvgl_tft/st7735s.h
@@ -131,7 +131,6 @@ extern "C" {
 
 void st7735s_init(void);
 void st7735s_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map);
-void st7735s_enable_backlight(bool backlight);
 void st7735s_sleep_in(void);
 void st7735s_sleep_out(void);
 

--- a/lvgl_tft/st7789.c
+++ b/lvgl_tft/st7789.c
@@ -94,11 +94,6 @@ void st7789_init(void)
     gpio_set_direction(ST7789_RST, GPIO_MODE_OUTPUT);
 #endif
 
-#if ST7789_ENABLE_BACKLIGHT_CONTROL
-    gpio_pad_select_gpio(ST7789_BCKL);
-    gpio_set_direction(ST7789_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
     //Reset the display
 #if !defined(ST7789_SOFT_RST)
     gpio_set_level(ST7789_RST, 0);
@@ -122,25 +117,7 @@ void st7789_init(void)
         cmd++;
     }
 
-    st7789_enable_backlight(true);
-
     st7789_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
-}
-
-void st7789_enable_backlight(bool backlight)
-{
-#if ST7789_ENABLE_BACKLIGHT_CONTROL
-    printf("%s backlight.\n", backlight ? "Enabling" : "Disabling");
-    uint32_t tmp = 0;
-
-#if (ST7789_BCKL_ACTIVE_LVL==1)
-    tmp = backlight ? 1 : 0;
-#else
-    tmp = backlight ? 0 : 1;
-#endif
-
-    gpio_set_level(ST7789_BCKL, tmp);
-#endif
 }
 
 /* The ST7789 display controller can drive 320*240 displays, when using a 240*240

--- a/lvgl_tft/st7789.h
+++ b/lvgl_tft/st7789.h
@@ -23,7 +23,6 @@ extern "C"
 
 #define ST7789_DC       CONFIG_LV_DISP_PIN_DC
 #define ST7789_RST      CONFIG_LV_DISP_PIN_RST
-#define ST7789_BCKL     CONFIG_LV_DISP_PIN_BCKL
 
 #if CONFIG_LV_DISP_USE_RST
   #if CONFIG_LV_DISP_ST7789_SOFT_RESET
@@ -33,15 +32,7 @@ extern "C"
   #define ST7789_SOFT_RST
 #endif
 
-
-#define ST7789_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
 #define ST7789_INVERT_COLORS            CONFIG_LV_INVERT_COLORS
-
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-  #define ST7789_BCKL_ACTIVE_LVL 1
-#else
-  #define ST7789_BCKL_ACTIVE_LVL 0
-#endif
 
 /* ST7789 commands */
 #define ST7789_NOP      0x00
@@ -121,7 +112,6 @@ extern "C"
 
 void st7789_init(void);
 void st7789_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
-void st7789_enable_backlight(bool backlight);
 
 void st7789_send_cmd(uint8_t cmd);
 void st7789_send_data(void *data, uint16_t length);

--- a/lvgl_tft/st7796s.c
+++ b/lvgl_tft/st7796s.c
@@ -81,16 +81,6 @@ void st7796s_init(void)
 		{0, {0}, 0xff},
 	};
 
-#if ST7796S_BCKL == 15
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_PIN_INTR_DISABLE;
-	io_conf.mode = GPIO_MODE_OUTPUT;
-	io_conf.pin_bit_mask = GPIO_SEL_15;
-	io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
-	io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
-	gpio_config(&io_conf);
-#endif
-
 	//Initialize non-SPI GPIOs
 	gpio_pad_select_gpio(ST7796S_DC);
 	gpio_set_direction(ST7796S_DC, GPIO_MODE_OUTPUT);
@@ -98,14 +88,7 @@ void st7796s_init(void)
 #if ST7796S_USE_RST
 	gpio_pad_select_gpio(ST7796S_RST);
 	gpio_set_direction(ST7796S_RST, GPIO_MODE_OUTPUT);
-#endif
 
-#if ST7796S_ENABLE_BACKLIGHT_CONTROL
-	gpio_pad_select_gpio(ST7796S_BCKL);
-	gpio_set_direction(ST7796S_BCKL, GPIO_MODE_OUTPUT);
-#endif
-
-#if ST7796S_USE_RST
 	//Reset the display
 	gpio_set_level(ST7796S_RST, 0);
 	vTaskDelay(100 / portTICK_RATE_MS);
@@ -127,8 +110,6 @@ void st7796s_init(void)
 		}
 		cmd++;
 	}
-
-	st7796s_enable_backlight(true);
 
 	st7796s_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 
@@ -165,22 +146,6 @@ void st7796s_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_
 	uint32_t size = lv_area_get_width(area) * lv_area_get_height(area);
 
 	st7796s_send_color((void *)color_map, size * 2);
-}
-
-void st7796s_enable_backlight(bool backlight)
-{
-#if ST7796S_ENABLE_BACKLIGHT_CONTROL
-	ESP_LOGI(TAG, "%s backlight.", backlight ? "Enabling" : "Disabling");
-	uint32_t tmp = 0;
-
-#if (ST7796S_BCKL_ACTIVE_LVL == 1)
-	tmp = backlight ? 1 : 0;
-#else
-	tmp = backlight ? 0 : 1;
-#endif
-
-	gpio_set_level(ST7796S_BCKL, tmp);
-#endif
 }
 
 void st7796s_sleep_in()

--- a/lvgl_tft/st7796s.h
+++ b/lvgl_tft/st7796s.h
@@ -26,20 +26,12 @@ extern "C"
 /*********************
  *      DEFINES
  *********************/
-#define ST7796S_DC      CONFIG_LV_DISP_PIN_DC
-#define ST7796S_RST     CONFIG_LV_DISP_PIN_RST
-#define ST7796S_USE_RST CONFIG_LV_DISP_USE_RST
-#define ST7796S_BCKL    CONFIG_LV_DISP_PIN_BCKL
-
-#define ST7796S_ENABLE_BACKLIGHT_CONTROL CONFIG_LV_ENABLE_BACKLIGHT_CONTROL
-#define ST7796S_INVERT_COLORS CONFIG_LV_INVERT_COLORS
+#define ST7796S_DC                  CONFIG_LV_DISP_PIN_DC
+#define ST7796S_RST                 CONFIG_LV_DISP_PIN_RST
+#define ST7796S_USE_RST             CONFIG_LV_DISP_USE_RST
+#define ST7796S_INVERT_COLORS       CONFIG_LV_INVERT_COLORS
 #define ST7796S_DISPLAY_ORIENTATION CONFIG_LV_DISPLAY_ORIENTATION
 
-#if CONFIG_LV_BACKLIGHT_ACTIVE_LVL
-#define ST7796S_BCKL_ACTIVE_LVL 1
-#else
-#define ST7796S_BCKL_ACTIVE_LVL 0
-#endif
 
 /*******************
  * ST7796S REGS
@@ -119,7 +111,6 @@ extern "C"
 
   void st7796s_init(void);
   void st7796s_flush(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_map);
-  void st7796s_enable_backlight(bool backlight);
 
   /**********************
  *      MACROS


### PR DESCRIPTION
Related: https://github.com/lvgl/lvgl_esp32_drivers/pull/74

Changes in this PR:

- enable brightness control from menuconfig
- carve-out backlight control from TFT drivers
- support for multiple displays
- support for (future) runtime configuration

TODOs:

- [x] Carve out backlight control
- [x] Adapt existing display drivers
- [x] Update Kconfig
- [x] Compile with all existing drivers
- [x] Compile with IDF v 4.2 and below