### PR TITLE
feat(lv_port): Add abstraction for busy signal

### DIFF
--- a/lv_port/lv_port_display_espressif.c
+++ b/lv_port/lv_port_display_espressif.c
@@ -40,16 +40,16 @@ void display_port_gpio_rst(lv_disp_drv_t *drv, uint8_t state)
 #endif
 }
 
-display_port_busy_t display_port_gpio_is_busy(lv_disp_drv_t *drv)
+bool display_port_gpio_is_busy(lv_disp_drv_t *drv)
 {
     (void) drv;
 
-    display_port_busy_t device_busy = DISPLAY_PORT_DEVICE_NOT_BUSY;
+    bool device_busy = false;
 
 #ifdef CONFIG_LV_DISP_PIN_BUSY
     /* FIXME Assuming the busy signal in logic 1 means the device is busy */
     if (gpio_get_level(CONFIG_LV_DISP_PIN_BUSY) == 1) {
-        device_busy = DISPLAY_PORT_DEVICE_IS_BUSY;
+        device_busy = true;
     }
 #endif
 

--- a/lv_port/lv_port_display_espressif.c
+++ b/lv_port/lv_port_display_espressif.c
@@ -39,3 +39,19 @@ void display_port_gpio_rst(lv_disp_drv_t *drv, uint8_t state)
     gpio_set_level(CONFIG_LV_DISP_PIN_RST, state);
 #endif
 }
+
+display_port_busy_t display_port_gpio_is_busy(lv_disp_drv_t *drv)
+{
+    (void) drv;
+
+    display_port_busy_t device_busy = DISPLAY_PORT_DEVICE_NOT_BUSY;
+
+#ifdef CONFIG_LV_DISP_PIN_BUSY
+    /* FIXME Assuming the busy signal in logic 1 means the device is busy */
+    if (gpio_get_level(CONFIG_LV_DISP_PIN_BUSY) == 1) {
+        device_busy = DISPLAY_PORT_DEVICE_IS_BUSY;
+    }
+#endif
+
+    return device_busy;
+}

--- a/lvgl_tft/display_port.h
+++ b/lvgl_tft/display_port.h
@@ -12,13 +12,8 @@ extern "C"
 #include "lvgl/lvgl.h"
 #endif
 
-/** Display is busy port
- * Useful for eink displays that need to poll their BUSY signal */
-typedef enum {
-    DISPLAY_PORT_DEVICE_NOT_BUSY,
-    DISPLAY_PORT_DEVICE_IS_BUSY,
-    /* NOTE Operation should not be interrupted when the device is busy */
-} display_port_busy_t;
+#include <stdint.h>
+#include <stdbool.h>
 
 /**
  * Busy wait delay port
@@ -57,10 +52,9 @@ void display_port_gpio_rst(lv_disp_drv_t *drv, uint8_t state);
  *
  * @param drv Pointer to driver See @ref lv_disp_drv_t
  *
- * @retval Returns DISPLAY_PORT_DEVICE_NOT_BUSY when display is not busy,
- * DISPLAY_PORT_DEVICE_IS_BUSY otherwise.
+ * @retval Returns false when display is not busy, true otherwise.
  */
-display_port_busy_t display_port_gpio_is_busy(lv_disp_drv_t *drv);
+bool display_port_gpio_is_busy(lv_disp_drv_t *drv);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lvgl_tft/display_port.h
+++ b/lvgl_tft/display_port.h
@@ -12,6 +12,14 @@ extern "C"
 #include "lvgl/lvgl.h"
 #endif
 
+/** Display is busy port
+ * Useful for eink displays that need to poll their BUSY signal */
+typedef enum {
+    DISPLAY_PORT_DEVICE_NOT_BUSY,
+    DISPLAY_PORT_DEVICE_IS_BUSY,
+    /* NOTE Operation should not be interrupted when the device is busy */
+} display_port_busy_t;
+
 /**
  * Busy wait delay port
  *
@@ -43,6 +51,16 @@ void display_port_gpio_dc(lv_disp_drv_t *drv, uint8_t state);
  * @param state State of the reset signal, 1 for logic high, 0 for logic low
  */
 void display_port_gpio_rst(lv_disp_drv_t *drv, uint8_t state);
+
+/**
+ * Display is busy port
+ *
+ * @param drv Pointer to driver See @ref lv_disp_drv_t
+ *
+ * @retval Returns DISPLAY_PORT_DEVICE_NOT_BUSY when display is not busy,
+ * DISPLAY_PORT_DEVICE_IS_BUSY otherwise.
+ */
+display_port_busy_t display_port_gpio_is_busy(lv_disp_drv_t *drv);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
This signal can be used when driving eink displays. The test for this will be porting the `il3820` display driver to the new driver abstraction layer (with the new capabilities added in this PR).