### PR TITLE
Update (initialization) helpers

### DIFF
--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -134,6 +134,39 @@ void lvgl_driver_init(void)
 #endif
 }
 
+void display_bsp_init_io(void)
+{
+    esp_err_t err = ESP_OK;
+    gpio_config_t io_conf;
+
+#ifdef CONFIG_LV_DISPLAY_USE_DC
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pin_bit_mask = (1ULL << CONFIG_LV_DISP_PIN_DC);
+    err = gpio_config(&io_conf);
+    ESP_ERROR_CHECK(err);
+#endif
+
+#ifdef CONFIG_LV_DISP_USE_RST
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pin_bit_mask = (1ULL << CONFIG_LV_DISP_PIN_RST);
+    err = gpio_config(&io_conf);
+    ESP_ERROR_CHECK(err);
+#endif
+
+#ifndef CONFIG_LV_DISP_BACKLIGHT_OFF
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pin_bit_mask = (1ULL << CONFIG_LV_DISP_PIN_BCKL);
+    err = gpio_config(&io_conf);
+    ESP_ERROR_CHECK(err);
+#endif
+
+#ifdef CONFIG_LV_DISP_PIN_BUSY
+    io_conf.mode = GPIO_MODE_INPUT;
+    io_conf.pin_bit_mask = (1ULL << CONFIG_LV_DISP_PIN_BUSY);
+    err = gpio_config(&io_conf);
+    ESP_ERROR_CHECK(err);
+#endif
+}
 
 /* Initialize spi bus master
  *

--- a/lvgl_helpers.h
+++ b/lvgl_helpers.h
@@ -98,6 +98,8 @@ void lvgl_driver_init(void);
 bool lvgl_spi_driver_init(int host, int miso_pin, int mosi_pin, int sclk_pin,
     int max_transfer_sz, int dma_channel, int quadwp_pin, int quadhd_pin);
 
+/* Initialize display GPIOs, e.g. DC and RST pins */
+void display_bsp_init_io(void);
 /**********************
  *      MACROS
  **********************/


### PR DESCRIPTION
Adds helper function to initialize GPIOs, this avoids having to configure and initialize GPIOs in the drivers init function.

Closes #128

Any suggestions with the name of the function are welcome. Same with `lvgl_driver_init`, now it only initializes the SPI/I2C peripheral.