### PR TITLE
Cleanup lvgl_interface_init

### DIFF
--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -47,6 +47,11 @@
  */
 static int calculate_spi_max_transfer_size(const int display_buffer_size);
 
+/**
+ * Handle FT81X initialization as it's a particular case
+ */
+static void init_ft81x(int dma_channel);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -79,22 +84,7 @@ void lvgl_interface_init(void)
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
-    ESP_LOGI(TAG, "Initializing SPI master for FT81X");
-
-    size_t display_buffer_size = lvgl_get_display_buffer_size();
-    int spi_max_transfer_size = calculate_spi_max_transfer_size(display_buffer_size);
-
-    lvgl_spi_driver_init(TFT_SPI_HOST,
-        DISP_SPI_MISO, DISP_SPI_MOSI, DISP_SPI_CLK,
-        spi_max_transfer_size, dma_channel,
-        DISP_SPI_IO2, DISP_SPI_IO3);
-
-    disp_spi_add_device(TFT_SPI_HOST);
-
-#if defined (CONFIG_LV_TOUCH_CONTROLLER_FT81X)
-    touch_driver_init();
-#endif
-
+    init_ft81x(dma_channel);
     return;
 #endif
 
@@ -332,4 +322,19 @@ static int calculate_spi_max_transfer_size(const int display_buffer_size)
 #endif
     
     return retval;
+}
+
+static void init_ft81x(int dma_channel)
+{
+    size_t display_buffer_size = lvgl_get_display_buffer_size();
+    int spi_max_transfer_size = calculate_spi_max_transfer_size(display_buffer_size);
+
+    lvgl_spi_driver_init(TFT_SPI_HOST, DISP_SPI_MISO, DISP_SPI_MOSI, DISP_SPI_CLK,
+        spi_max_transfer_size, dma_channel, DISP_SPI_IO2, DISP_SPI_IO3);
+
+    disp_spi_add_device(TFT_SPI_HOST);
+
+#if defined (CONFIG_LV_TOUCH_CONTROLLER_FT81X)
+    touch_driver_init();
+#endif
 }

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -80,9 +80,9 @@ void lvgl_interface_init(void)
     /* SPI DMA Channel selection
      * SPI_DMA_CH1 is only defined for ESP32, so let the driver choose which
      * channel to use, and use the proven channel 1 on esp32 targets */
-    int dma_channel = SPI_DMA_CH_AUTO;
+    int dma_channel = 3;
 #if defined (CONFIG_IDF_TARGET_ESP32)
-    dma_channel = SPI_DMA_CH1;
+    dma_channel = 1;
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
@@ -126,7 +126,7 @@ void lvgl_interface_init(void)
     ESP_LOGI(TAG, "Initializing SPI master for touch");
 
 #if defined (CONFIG_IDF_TARGET_ESP32)
-    dma_channel = SPI_DMA_CH2;
+    dma_channel = 2;
 #endif
 
     lvgl_spi_driver_init(TOUCH_SPI_HOST, TP_SPI_MISO, TP_SPI_MOSI, TP_SPI_CLK,

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -6,8 +6,11 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "sdkconfig.h"
 #include "lvgl_helpers.h"
+
+#include "sdkconfig.h"
+
+#include "driver/spi_common.h"
 #include "esp_log.h"
 #include "esp_idf_version.h"
 

--- a/lvgl_helpers.h
+++ b/lvgl_helpers.h
@@ -14,8 +14,6 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
-#include "driver/spi_common.h"
-
 #include "lvgl_spi_conf.h"
 #include "lvgl_tft/disp_driver.h"
 #include "lvgl_tft/esp_lcd_backlight.h"


### PR DESCRIPTION
Start the cleanup of `lvgl_interface_init` function, further cleanup is needed in the Kconfig files in order to remove unused symbols.