### PR TITLE
Cleanup lvgl helpers

### DIFF
--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -261,7 +261,7 @@ size_t lvgl_get_display_buffer_size(void)
  * We could use the ESP_IDF_VERSION_VAL macro available in the "esp_idf_version.h"
  * header available since ESP-IDF v4.
  */
-bool lvgl_spi_driver_init(spi_host_device_t host,
+bool lvgl_spi_driver_init(int host,
     int miso_pin, int mosi_pin, int sclk_pin,
     int max_transfer_sz,
     int dma_channel,
@@ -295,7 +295,7 @@ bool lvgl_spi_driver_init(spi_host_device_t host,
     ESP_LOGI(TAG, "Initializing SPI bus...");
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
-    esp_err_t ret = spi_bus_initialize(host, &buscfg, (spi_dma_chan_t)dma_channel);
+    esp_err_t ret = spi_bus_initialize((spi_host_device_t) host, &buscfg, (spi_dma_chan_t)dma_channel);
 #else
     esp_err_t ret = spi_bus_initialize(host, &buscfg, dma_channel);
 #endif

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -47,6 +47,11 @@
  */
 static int calculate_spi_max_transfer_size(const int display_buffer_size);
 
+/**
+ * Handle FT81X initialization as it's a particular case
+ */
+static void init_ft81x(int dma_channel);
+
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -79,22 +84,7 @@ void lvgl_interface_init(void)
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
-    ESP_LOGI(TAG, "Initializing SPI master for FT81X");
-
-    size_t display_buffer_size = lvgl_get_display_buffer_size();
-    int spi_max_transfer_size = calculate_spi_max_transfer_size(display_buffer_size);
-
-    lvgl_spi_driver_init(TFT_SPI_HOST,
-        DISP_SPI_MISO, DISP_SPI_MOSI, DISP_SPI_CLK,
-        spi_max_transfer_size, dma_channel,
-        DISP_SPI_IO2, DISP_SPI_IO3);
-
-    disp_spi_add_device(TFT_SPI_HOST);
-
-#if defined (CONFIG_LV_TOUCH_CONTROLLER_FT81X)
-    touch_driver_init();
-#endif
-
+    init_ft81x(dma_channel);
     return;
 #endif
 
@@ -332,4 +322,19 @@ static int calculate_spi_max_transfer_size(const int display_buffer_size)
 #endif
     
     return retval;
+}
+
+static void init_ft81x(int dma_channel)
+{
+    size_t display_buffer_size = lvgl_get_display_buffer_size();
+    int spi_max_transfer_size = calculate_spi_max_transfer_size(display_buffer_size);
+
+    lvgl_spi_driver_init(TFT_SPI_HOST, DISP_SPI_MISO, DISP_SPI_MOSI, DISP_SPI_CLK,
+        spi_max_transfer_size, dma_channel, DISP_SPI_IO2, DISP_SPI_IO3);
+
+    disp_spi_add_device(TFT_SPI_HOST);
+
+#if defined (CONFIG_LV_TOUCH_CONTROLLER_FT81X)
+    touch_driver_init();
+#endif
 }

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -80,9 +80,9 @@ void lvgl_interface_init(void)
     /* SPI DMA Channel selection
      * SPI_DMA_CH1 is only defined for ESP32, so let the driver choose which
      * channel to use, and use the proven channel 1 on esp32 targets */
-    int dma_channel = SPI_DMA_CH_AUTO;
+    int dma_channel = 3;
 #if defined (CONFIG_IDF_TARGET_ESP32)
-    dma_channel = SPI_DMA_CH1;
+    dma_channel = 1;
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
@@ -126,7 +126,7 @@ void lvgl_interface_init(void)
     ESP_LOGI(TAG, "Initializing SPI master for touch");
 
 #if defined (CONFIG_IDF_TARGET_ESP32)
-    dma_channel = SPI_DMA_CH2;
+    dma_channel = 2;
 #endif
 
     lvgl_spi_driver_init(TOUCH_SPI_HOST, TP_SPI_MISO, TP_SPI_MOSI, TP_SPI_CLK,

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -14,6 +14,8 @@
 #include "esp_log.h"
 #include "esp_idf_version.h"
 
+#include "hal/spi_hal.h"
+
 #include "lvgl_tft/disp_spi.h"
 #include "lvgl_touch/tp_spi.h"
 

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -6,8 +6,11 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "sdkconfig.h"
 #include "lvgl_helpers.h"
+
+#include "sdkconfig.h"
+
+#include "driver/spi_common.h"
 #include "esp_log.h"
 #include "esp_idf_version.h"
 

--- a/lvgl_helpers.h
+++ b/lvgl_helpers.h
@@ -37,7 +37,7 @@ void lvgl_i2c_locking(void* leader);
 void lvgl_interface_init(void);
 
 /* Initialize SPI master  */
-bool lvgl_spi_driver_init(spi_host_device_t host, int miso_pin, int mosi_pin, int sclk_pin,
+bool lvgl_spi_driver_init(int host, int miso_pin, int mosi_pin, int sclk_pin,
     int max_transfer_sz, int dma_channel, int quadwp_pin, int quadhd_pin);
 
 /* Initialize display GPIOs, e.g. DC and RST pins */

--- a/lvgl_helpers.h
+++ b/lvgl_helpers.h
@@ -14,8 +14,6 @@ extern "C" {
  *********************/
 #include <stdbool.h>
 
-#include "driver/spi_common.h"
-
 #include "lvgl_spi_conf.h"
 #include "lvgl_tft/disp_driver.h"
 #include "lvgl_tft/esp_lcd_backlight.h"

--- a/lvgl_spi_conf.h
+++ b/lvgl_spi_conf.h
@@ -68,6 +68,8 @@ extern "C" {
 #define TFT_SPI_HOST SPI2_HOST
 #elif defined (CONFIG_LV_TFT_DISPLAY_SPI3_HOST)
 #define TFT_SPI_HOST SPI3_HOST
+#else
+#define TFT_SPI_HOST
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_SPI_HALF_DUPLEX)

--- a/lvgl_spi_conf.h
+++ b/lvgl_spi_conf.h
@@ -69,7 +69,8 @@ extern "C" {
 #elif defined (CONFIG_LV_TFT_DISPLAY_SPI3_HOST)
 #define TFT_SPI_HOST SPI3_HOST
 #else
-#define TFT_SPI_HOST
+/* FIXME: This is not expected to work, only a placeholder */
+#define TFT_SPI_HOST 0
 #endif
 
 #if defined (CONFIG_LV_TFT_DISPLAY_SPI_HALF_DUPLEX)

--- a/lvgl_tft/ili9486.c
+++ b/lvgl_tft/ili9486.c
@@ -35,7 +35,7 @@ static void ili9486_set_orientation(uint8_t orientation);
 static void ili9486_send_cmd(uint8_t cmd);
 static void ili9486_send_data(void * data, uint16_t length);
 static void ili9486_send_color(void * data, uint16_t length);
-
+static void ili9486_reset(void);
 /**********************
  *  STATIC VARIABLES
  **********************/
@@ -50,77 +50,62 @@ static void ili9486_send_color(void * data, uint16_t length);
 
 void ili9486_init(void)
 {
-	lcd_init_cmd_t ili_init_cmds[]={
-		{0x11, {0}, 0x80},
-		{0x3A, {0x55}, 1},
-		{0x2C, {0x44}, 1},
-		{0xC5, {0x00, 0x00, 0x00, 0x00}, 4},
-		{0xE0, {0x0F, 0x1F, 0x1C, 0x0C, 0x0F, 0x08, 0x48, 0x98, 0x37, 0x0A, 0x13, 0x04, 0x11, 0x0D, 0x00}, 15},
-		{0XE1, {0x0F, 0x32, 0x2E, 0x0B, 0x0D, 0x05, 0x47, 0x75, 0x37, 0x06, 0x10, 0x03, 0x24, 0x20, 0x00}, 15},
-		{0x20, {0}, 0},				/* display inversion OFF */
-		{0x36, {0x48}, 1},
-		{0x29, {0}, 0x80},			/* display on */
-		{0x00, {0}, 0xff},
-	};
+    lcd_init_cmd_t ili_init_cmds[]={
+        {0x11, {0}, 0x80},
+        {0x3A, {0x55}, 1},
+        {0x2C, {0x44}, 1},
+        {0xC5, {0x00, 0x00, 0x00, 0x00}, 4},
+        {0xE0, {0x0F, 0x1F, 0x1C, 0x0C, 0x0F, 0x08, 0x48, 0x98, 0x37, 0x0A, 0x13, 0x04, 0x11, 0x0D, 0x00}, 15},
+        {0XE1, {0x0F, 0x32, 0x2E, 0x0B, 0x0D, 0x05, 0x47, 0x75, 0x37, 0x06, 0x10, 0x03, 0x24, 0x20, 0x00}, 15},
+        {0x20, {0}, 0},				/* display inversion OFF */
+        {0x36, {0x48}, 1},
+        {0x29, {0}, 0x80},			/* display on */
+        {0x00, {0}, 0xff},
+    };
 
-	//Initialize non-SPI GPIOs
-    gpio_pad_select_gpio(ILI9486_DC);
-	gpio_set_direction(ILI9486_DC, GPIO_MODE_OUTPUT);
+    ili9486_reset();
 
-#if ILI9486_USE_RST
-    gpio_pad_select_gpio(ILI9486_RST);
-	gpio_set_direction(ILI9486_RST, GPIO_MODE_OUTPUT);
+    LV_LOG_INFO("ILI9486 Initialization.");
 
-	//Reset the display
-	gpio_set_level(ILI9486_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
-	gpio_set_level(ILI9486_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
-#endif
-
-	LV_LOG_INFO("ILI9486 Initialization.");
-
-	//Send all the commands
-	uint16_t cmd = 0;
-	while (ili_init_cmds[cmd].databytes!=0xff) {
-		ili9486_send_cmd(ili_init_cmds[cmd].cmd);
-		ili9486_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
-		if (ili_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
-		}
-		cmd++;
-	}
+    //Send all the commands
+    uint16_t cmd = 0;
+    while (ili_init_cmds[cmd].databytes!=0xff) {
+        ili9486_send_cmd(ili_init_cmds[cmd].cmd);
+        ili9486_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
+        if (ili_init_cmds[cmd].databytes & 0x80) {
+                vTaskDelay(100 / portTICK_RATE_MS);
+        }
+        cmd++;
+    }
 
     ili9486_set_orientation(CONFIG_LV_DISPLAY_ORIENTATION);
 }
 
 void ili9486_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * color_map)
 {
-	uint8_t data[4] = {0};
-    uint32_t size = 0;
+    uint8_t data[4] = {0};
+    /* 2 is the number of bytes in color depth */
+    uint32_t size = lv_area_get_width(area) * lv_area_get_height(area) * 2;
 
-	/*Column addresses*/
-	ili9486_send_cmd(0x2A);
-	data[0] = (area->x1 >> 8) & 0xFF;
-	data[1] = area->x1 & 0xFF;
-	data[2] = (area->x2 >> 8) & 0xFF;
-	data[3] = area->x2 & 0xFF;
-	ili9486_send_data(data, 4);
+    /*Column addresses*/
+    ili9486_send_cmd(0x2A);
+    data[0] = (area->x1 >> 8) & 0xFF;
+    data[1] = area->x1 & 0xFF;
+    data[2] = (area->x2 >> 8) & 0xFF;
+    data[3] = area->x2 & 0xFF;
+    ili9486_send_data(data, 4);
 
-	/*Page addresses*/
-	ili9486_send_cmd(0x2B);
-	data[0] = (area->y1 >> 8) & 0xFF;
-	data[1] = area->y1 & 0xFF;
-	data[2] = (area->y2 >> 8) & 0xFF;
-	data[3] = area->y2 & 0xFF;
-	ili9486_send_data(data, 4);
+    /*Page addresses*/
+    ili9486_send_cmd(0x2B);
+    data[0] = (area->y1 >> 8) & 0xFF;
+    data[1] = area->y1 & 0xFF;
+    data[2] = (area->y2 >> 8) & 0xFF;
+    data[3] = area->y2 & 0xFF;
+    ili9486_send_data(data, 4);
 
-	/*Memory write*/
-	ili9486_send_cmd(0x2C);
-
-	size = lv_area_get_width(area) * lv_area_get_height(area);
-
-    ili9486_send_color((void*) color_map, size * 2);
+    /*Memory write*/
+    ili9486_send_cmd(0x2C);
+    ili9486_send_color((void*) color_map, size);
 }
 
 /**********************
@@ -128,30 +113,30 @@ void ili9486_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
  **********************/
 static void ili9486_send_cmd(uint8_t cmd)
 {
-	uint8_t to16bit[] = {
-	    0x00, cmd
-        };
+    uint8_t to16bit[] = {
+        0x00, cmd
+    };
 
-	disp_wait_for_pending_transactions();
-	gpio_set_level(ILI9486_DC, 0);	 /*Command mode*/
-	disp_spi_send_data(to16bit, sizeof to16bit);
+    disp_wait_for_pending_transactions();
+    gpio_set_level(ILI9486_DC, 0);	 /*Command mode*/
+    disp_spi_send_data(to16bit, sizeof to16bit);
 }
 
 static void ili9486_send_data(void * data, uint16_t length)
 {
-	uint32_t i;
-	uint8_t to16bit[32];
-	uint8_t * dummy = data;
+    uint32_t i;
+    uint8_t to16bit[32];
+    uint8_t * dummy = data;
 
-	for(i=0; i < (length); i++)
-	{
-	  to16bit[2*i+1] = dummy[i];
-	  to16bit[2*i] = 0x00;
-	}
+    for(i=0; i < (length); i++)
+    {
+      to16bit[2*i+1] = dummy[i];
+      to16bit[2*i] = 0x00;
+    }
 
-	disp_wait_for_pending_transactions();
-	gpio_set_level(ILI9486_DC, 1);	 /*Data mode*/
-	disp_spi_send_data(to16bit, (length*2));
+    disp_wait_for_pending_transactions();
+    gpio_set_level(ILI9486_DC, 1);	 /*Data mode*/
+    disp_spi_send_data(to16bit, (length*2));
 }
 
 static void ili9486_send_color(void * data, uint16_t length)
@@ -178,4 +163,14 @@ static void ili9486_set_orientation(uint8_t orientation)
 
     ili9486_send_cmd(0x36);
     ili9486_send_data((void *) &data[orientation], 1);
+}
+
+static void ili9486_reset(void)
+{
+#if ILI9486_USE_RST
+    gpio_set_level(ILI9486_RST, 0);
+    vTaskDelay(100 / portTICK_RATE_MS);
+    gpio_set_level(ILI9486_RST, 1);
+    vTaskDelay(100 / portTICK_RATE_MS);
+#endif
 }


### PR DESCRIPTION
Cleanup the lvgl_helpers files. We also need to update the README to reflect the changes when using `lvgl_interface_init`