### PR TITLE
Add bgr option for hx8357

### DIFF
--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -351,6 +351,13 @@ menu "LVGL TFT Display controller"
             select LV_TFT_DISPLAY_MONOCHROME
     endchoice
 
+    config LV_TFT_DISPLAY_BGR
+        bool "use BGR color order" if LV_TFT_DISPLAY_CONTROLLER_HX8357
+        #depends on LV_TFT_DISPLAY_CONTROLLER_HX8357
+        default false
+        help
+            use Blue-Gren_Red pixel order.
+
     config CUSTOM_DISPLAY_BUFFER_SIZE
         bool "Use custom display buffer size (bytes)"
         help

--- a/lvgl_tft/Kconfig
+++ b/lvgl_tft/Kconfig
@@ -353,8 +353,7 @@ menu "LVGL TFT Display controller"
 
     config LV_TFT_DISPLAY_BGR
         bool "use BGR color order" if LV_TFT_DISPLAY_CONTROLLER_HX8357
-        #depends on LV_TFT_DISPLAY_CONTROLLER_HX8357
-        default false
+        default n
         help
             use Blue-Gren_Red pixel order.
 

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -32,6 +32,12 @@
 #define MADCTL_BGR 0x08 ///< Blue-Green-Red pixel order
 #define MADCTL_MH  0x04 ///< LCD refresh right to left
 
+#if HX8357_BGR
+#define MADCTL_RGB_OR_BGR MADCTL_BGR
+#else
+#define MADCTL_RGB_OR_BGR MADCTL_RGB
+#endif
+
 /**********************
  *      TYPEDEFS
  **********************/
@@ -229,16 +235,16 @@ void hx8357_set_rotation(uint8_t r)
 
 	switch(r) {
 		case 0:
-			r = MADCTL_MX | MADCTL_MY | MADCTL_RGB;
+			r = MADCTL_MX | MADCTL_MY | MADCTL_RGB_OR_BGR;
 			break;
 		case 1:
-			r = MADCTL_MV | MADCTL_MY | MADCTL_RGB;
+			r = MADCTL_MV | MADCTL_MY | MADCTL_RGB_OR_BGR;
       		break;
 		case 2:
-			r = MADCTL_RGB;
+			r = MADCTL_RGB_OR_BGR;
   			break;
 		case 3:
-			r = MADCTL_MX | MADCTL_MV | MADCTL_RGB;
+			r = MADCTL_MX | MADCTL_MV | MADCTL_RGB_OR_BGR;
 		break;
 	}
 

--- a/lvgl_tft/hx8357.h
+++ b/lvgl_tft/hx8357.h
@@ -39,6 +39,7 @@ extern "C" {
 #define HX8357_RST            CONFIG_LV_DISP_PIN_RST
 #define HX8357_USE_RST        CONFIG_LV_DISP_USE_RST
 #define HX8357_INVERT_COLORS  CONFIG_LV_INVERT_COLORS
+#define HX8357_BGR            CONFIG_LV_TFT_DISPLAY_BGR
 
 
 /*******************


### PR DESCRIPTION
I have a [Waveshare 2.8inch Resistive Touch LCD, 320×240](https://www.waveshare.com/2.8inch-resistive-touch-lcd.htm) that seems to have swapped RED and BLUE.  This PR adds a configuration option to set the BGR bit when initializing the display.

The display controller is listed as a hx8347 and seems compatible with the hx8357 driver, including the RGP/BGR bit.
