### PR TITLE
Initial changes to support ESP-IDF v5.0.0

### DIFF
--- a/lvgl_i2c/i2c_manager.c
+++ b/lvgl_i2c/i2c_manager.c
@@ -66,8 +66,8 @@ static const uint8_t ACK_CHECK_EN = 1;
 		#define I2C_MANAGER_0_PULLUPS 	false
 	#endif
 
-	#define I2C_MANAGER_0_TIMEOUT 		( CONFIG_I2C_MANAGER_0_TIMEOUT / portTICK_RATE_MS )
-	#define I2C_MANAGER_0_LOCK_TIMEOUT	( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT / portTICK_RATE_MS )
+	#define I2C_MANAGER_0_TIMEOUT 		( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_TIMEOUT ) )
+	#define I2C_MANAGER_0_LOCK_TIMEOUT	( ( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT ) )
 #endif
 
 
@@ -79,8 +79,8 @@ static const uint8_t ACK_CHECK_EN = 1;
 		#define I2C_MANAGER_1_PULLUPS 	false
 	#endif
 
-	#define I2C_MANAGER_1_TIMEOUT 		( CONFIG_I2C_MANAGER_1_TIMEOUT / portTICK_RATE_MS )
-	#define I2C_MANAGER_1_LOCK_TIMEOUT	( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT / portTICK_RATE_MS )
+	#define I2C_MANAGER_1_TIMEOUT 		( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_TIMEOUT ) )
+	#define I2C_MANAGER_1_LOCK_TIMEOUT	( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT ) )
 #endif
 
 #define ERROR_PORT(port, fail) { \
@@ -222,7 +222,7 @@ esp_err_t I2C_FN(_read)(i2c_port_t port, uint16_t addr, uint32_t reg, uint8_t *b
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);
@@ -244,12 +244,12 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
 	TickType_t timeout = 0;
 	#if defined (I2C_ZERO)
 		if (port == I2C_NUM_0) {
-			timeout = (CONFIG_I2C_MANAGER_0_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_TIMEOUT );
 		}
 	#endif
 	#if defined (I2C_ONE)
 		if (port == I2C_NUM_1) {
-			timeout = (CONFIG_I2C_MANAGER_1_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_TIMEOUT );
 		}
 	#endif
 
@@ -271,7 +271,7 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);
@@ -294,12 +294,12 @@ esp_err_t I2C_FN(_lock)(i2c_port_t port) {
 	TickType_t timeout;
 	#if defined (I2C_ZERO)
 		if (port == I2C_NUM_0) {
-			timeout = (CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT );
 		}
 	#endif
 	#if defined (I2C_ONE)
 		if (port == I2C_NUM_1) {
-			timeout = (CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT );
 		}
 	#endif
 

--- a/lvgl_tft/EVE_commands.c
+++ b/lvgl_tft/EVE_commands.c
@@ -141,7 +141,7 @@ uint8_t SPIDummyReadBits = 0;					// Dummy bits for reading in DIO/QIO modes
 
 void DELAY_MS(uint16_t ms)
 {
-	vTaskDelay(ms / portTICK_PERIOD_MS);
+	vTaskDelay(pdMS_TO_TICKS(ms));
 }
 
 #if EVE_USE_PDN

--- a/lvgl_tft/FT81x.c
+++ b/lvgl_tft/FT81x.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 
 #include "FT81x.h"
 

--- a/lvgl_tft/GC9A01.c
+++ b/lvgl_tft/GC9A01.c
@@ -121,9 +121,9 @@ void GC9A01_init(void)
 
 	//Reset the display
 	gpio_set_level(GC9A01_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(GC9A01_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "Initialization.");
@@ -134,7 +134,7 @@ void GC9A01_init(void)
 		GC9A01_send_cmd(GC_init_cmds[cmd].cmd);
 		GC9A01_send_data(GC_init_cmds[cmd].data, GC_init_cmds[cmd].databytes&0x1F);
 		if (GC_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/GC9A01.c
+++ b/lvgl_tft/GC9A01.c
@@ -9,6 +9,7 @@
 #include "GC9A01.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/esp_lcd_backlight.c
+++ b/lvgl_tft/esp_lcd_backlight.c
@@ -11,6 +11,23 @@
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include "soc/ledc_periph.h" // to invert LEDC output on IDF version < v4.3
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "soc/gpio_sig_map.h" // 5.0
+#if defined (CONFIG_IDF_TARGET_ESP32)
+#include "esp32/rom/gpio.h"
+#endif
+#if defined (CONFIG_IDF_TARGET_ESP32S2)
+#include "esp32s2/rom/gpio.h"
+#endif
+#if defined (CONFIG_IDF_TARGET_ESP32S3)
+#include "esp32s3/rom/gpio.h"
+#endif
+#if defined (CONFIG_IDF_TARGET_ESP32C3)
+#include "esp32c3/rom/gpio.h"
+#endif
+#endif
 
 typedef struct {
     bool pwm_control; // true: LEDC is used, false: GPIO is used

--- a/lvgl_tft/esp_lcd_backlight.c
+++ b/lvgl_tft/esp_lcd_backlight.c
@@ -9,24 +9,13 @@
 #include "esp_lcd_backlight.h"
 #include "driver/ledc.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "soc/ledc_periph.h" // to invert LEDC output on IDF version < v4.3
 #include "esp_idf_version.h"
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-#include "soc/gpio_sig_map.h" // 5.0
-#if defined (CONFIG_IDF_TARGET_ESP32)
-#include "esp32/rom/gpio.h"
-#endif
-#if defined (CONFIG_IDF_TARGET_ESP32S2)
-#include "esp32s2/rom/gpio.h"
-#endif
-#if defined (CONFIG_IDF_TARGET_ESP32S3)
-#include "esp32s3/rom/gpio.h"
-#endif
-#if defined (CONFIG_IDF_TARGET_ESP32C3)
-#include "esp32c3/rom/gpio.h"
-#endif
+#include "soc/gpio_sig_map.h"
 #endif
 
 typedef struct {

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -169,9 +169,9 @@ void hx8357_init(void)
 
 	//Reset the display
 	gpio_set_level(HX8357_RST, 0);
-	vTaskDelay(10 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(10));
 	gpio_set_level(HX8357_RST, 1);
-	vTaskDelay(120 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(120));
 #endif
 
 	ESP_LOGI(TAG, "Initialization.");
@@ -192,7 +192,7 @@ void hx8357_init(void)
 			}
 		}
 		if (x & 0x80) {       // If high bit set...
-			vTaskDelay(numArgs * 5 / portTICK_RATE_MS); // numArgs is actually a delay time (5ms units)
+			vTaskDelay(numArgs * pdMS_TO_TICKS(5)); // numArgs is actually a delay time (5ms units)
 		}
 	}
 

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -18,6 +18,7 @@
 #include "hx8357.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include <esp_log.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/il3820.c
+++ b/lvgl_tft/il3820.c
@@ -30,6 +30,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
  *********************/
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/il3820.c
+++ b/lvgl_tft/il3820.c
@@ -208,9 +208,9 @@ void il3820_init(void)
 
     /* Harware reset */
     gpio_set_level( IL3820_RST_PIN, 0);
-    vTaskDelay(IL3820_RESET_DELAY / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(IL3820_RESET_DELAY));
     gpio_set_level( IL3820_RST_PIN, 1);
-    vTaskDelay(IL3820_RESET_DELAY / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(IL3820_RESET_DELAY));
 #endif
 
     /* Software reset */
@@ -267,14 +267,14 @@ static void il3820_waitbusy(int wait_ms)
 {
     int i = 0;
 
-    vTaskDelay(10 / portTICK_RATE_MS); // 10ms delay
+    vTaskDelay(pdMS_TO_TICKS(10)); // 10ms delay
 
     for(i = 0; i < (wait_ms * 10); i++) {
 	if(gpio_get_level(IL3820_BUSY_PIN) != IL3820_BUSY_LEVEL) {
             return;
         }
 
-        vTaskDelay(10 / portTICK_RATE_MS);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
     ESP_LOGE( TAG, "busy exceeded %dms", i*10 );

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -9,6 +9,7 @@
 #include "ili9163c.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -145,9 +145,9 @@ void ili9163c_init(void)
 
 	//Reset the display
 	gpio_set_level(ILI9163C_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ILI9163C_RST, 1);
-	vTaskDelay(150 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(150));
 
 	//Send all the commands
 	uint16_t cmd = 0;
@@ -157,7 +157,7 @@ void ili9163c_init(void)
 		ili9163c_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes & 0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80)
 		{
-			vTaskDelay(150 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(150));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/ili9341.c
+++ b/lvgl_tft/ili9341.c
@@ -9,6 +9,7 @@
 #include "ili9341.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "esp32/rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -90,9 +91,9 @@ void ili9341_init(void)
 
 	//Reset the display
 	gpio_set_level(ILI9341_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ILI9341_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "Initialization.");
@@ -103,7 +104,7 @@ void ili9341_init(void)
 		ili9341_send_cmd(ili_init_cmds[cmd].cmd);
 		ili9341_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/ili9341.c
+++ b/lvgl_tft/ili9341.c
@@ -9,7 +9,7 @@
 #include "ili9341.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
-#include "esp32/rom/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/ili9481.c
+++ b/lvgl_tft/ili9481.c
@@ -83,16 +83,16 @@ void ili9481_init(void)
 
     //Reset the display
     gpio_set_level(ILI9481_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9481_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
     ESP_LOGI(TAG, "ILI9481 initialization.");
 
     // Exit sleep
     ili9481_send_cmd(0x01);	/* Software reset */
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     //Send all the commands
     uint16_t cmd = 0;
@@ -100,7 +100,7 @@ void ili9481_init(void)
         ili9481_send_cmd(ili_init_cmds[cmd].cmd);
         ili9481_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
         if (ili_init_cmds[cmd].databytes & 0x80) {
-            vTaskDelay(100 / portTICK_RATE_MS);
+            vTaskDelay(pdMS_TO_TICKS(100));
         }
         cmd++;
     }

--- a/lvgl_tft/ili9481.c
+++ b/lvgl_tft/ili9481.c
@@ -8,6 +8,7 @@
 #include "ili9481.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
 

--- a/lvgl_tft/ili9486.c
+++ b/lvgl_tft/ili9486.c
@@ -75,9 +75,9 @@ void ili9486_init(void)
 
 	//Reset the display
 	gpio_set_level(ILI9486_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ILI9486_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "ILI9486 Initialization.");
@@ -88,7 +88,7 @@ void ili9486_init(void)
 		ili9486_send_cmd(ili_init_cmds[cmd].cmd);
 		ili9486_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/ili9486.c
+++ b/lvgl_tft/ili9486.c
@@ -9,6 +9,7 @@
 #include "ili9486.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/ili9488.c
+++ b/lvgl_tft/ili9488.c
@@ -8,6 +8,7 @@
 #include "ili9488.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
 

--- a/lvgl_tft/ili9488.c
+++ b/lvgl_tft/ili9488.c
@@ -85,16 +85,16 @@ void ili9488_init(void)
 
 	//Reset the display
 	gpio_set_level(ILI9488_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ILI9488_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "ILI9488 initialization.");
 
 	// Exit sleep
 	ili9488_send_cmd(0x01);	/* Software reset */
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 
 	//Send all the commands
 	uint16_t cmd = 0;
@@ -102,7 +102,7 @@ void ili9488_init(void)
 		ili9488_send_cmd(ili_init_cmds[cmd].cmd);
 		ili9488_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/pcd8544.c
+++ b/lvgl_tft/pcd8544.c
@@ -64,9 +64,9 @@ void pcd8544_init(void){
 
     // Reset the display
     gpio_set_level(PCD8544_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(PCD8544_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     pcd8544_send_cmd(0x21);     /* activate chip (PD=0), horizontal increment (V=0), enter extended command set (H=1) */
     pcd8544_send_cmd(0x06);     /* temp. control: b10 = 2  */

--- a/lvgl_tft/pcd8544.c
+++ b/lvgl_tft/pcd8544.c
@@ -8,7 +8,7 @@
 
 #include "disp_spi.h"
 #include "driver/gpio.h"
-
+#include "rom/gpio.h"
 #include <esp_log.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/ra8875.c
+++ b/lvgl_tft/ra8875.c
@@ -156,9 +156,9 @@ void ra8875_init(void)
 
     // Reset the RA8875
     gpio_set_level(RA8875_RST, 0);
-    vTaskDelay(DIV_ROUND_UP(100, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(100, portTICK_PERIOD_MS));
     gpio_set_level(RA8875_RST, 1);
-    vTaskDelay(DIV_ROUND_UP(100, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(100, portTICK_PERIOD_MS));
 #endif
 
     // Initalize RA8875 clocks (SPI must be decelerated before initializing clocks)
@@ -251,21 +251,21 @@ void ra8875_sleep_in(void)
     ra8875_configure_clocks(false);
 
     ra8875_write_cmd(RA8875_REG_PWRR, 0x00);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
     ra8875_write_cmd(RA8875_REG_PWRR, 0x02);           // Power and Display Control Register (PWRR)
 }
 
 void ra8875_sleep_out(void)
 {
     ra8875_write_cmd(RA8875_REG_PWRR, 0x00);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 
     ra8875_configure_clocks(true);
 
     disp_spi_change_device_speed(-1);
 
     ra8875_write_cmd(RA8875_REG_PWRR, 0x80);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 }
 
 uint8_t ra8875_read_cmd(uint8_t cmd)
@@ -298,7 +298,7 @@ void ra8875_configure_clocks(bool high_speed)
     vTaskDelay(1);
 
     ra8875_write_cmd(RA8875_REG_PCSR, PCSR_VAL);            // Pixel Clock Setting Register (PCSR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 }
 
 static void ra8875_set_window(unsigned int xs, unsigned int xe, unsigned int ys, unsigned int ye)

--- a/lvgl_tft/ra8875.c
+++ b/lvgl_tft/ra8875.c
@@ -9,6 +9,7 @@
 #include "ra8875.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/sh1107.c
+++ b/lvgl_tft/sh1107.c
@@ -101,9 +101,9 @@ void sh1107_init(void)
 
 	//Reset the display
 	gpio_set_level(SH1107_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(SH1107_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	//Send all the commands
@@ -112,7 +112,7 @@ void sh1107_init(void)
 	    sh1107_send_cmd(init_cmds[cmd].cmd);
 	    sh1107_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes&0x1F);
 	    if (init_cmds[cmd].databytes & 0x80) {
-		vTaskDelay(100 / portTICK_RATE_MS);
+		vTaskDelay(pdMS_TO_TICKS(100));
 	    }
 	    cmd++;
 	}

--- a/lvgl_tft/sh1107.c
+++ b/lvgl_tft/sh1107.c
@@ -9,6 +9,7 @@
 #include "sh1107.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/st7735s.c
+++ b/lvgl_tft/st7735s.c
@@ -9,6 +9,7 @@
 #include "st7735s.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_tft/st7735s.c
+++ b/lvgl_tft/st7735s.c
@@ -107,9 +107,9 @@ void st7735s_init(void)
 
 	//Reset the display
 	gpio_set_level(ST7735S_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ST7735S_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "ST7735S initialization.");
@@ -120,7 +120,7 @@ void st7735s_init(void)
 		st7735s_send_cmd(init_cmds[cmd].cmd);
 		st7735s_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes&0x1F);
 		if (init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/st7789.c
+++ b/lvgl_tft/st7789.c
@@ -97,9 +97,9 @@ void st7789_init(void)
     //Reset the display
 #if !defined(ST7789_SOFT_RST)
     gpio_set_level(ST7789_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ST7789_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #else
     st7789_send_cmd(ST7789_SWRESET);
 #endif
@@ -112,7 +112,7 @@ void st7789_init(void)
         st7789_send_cmd(st7789_init_cmds[cmd].cmd);
         st7789_send_data(st7789_init_cmds[cmd].data, st7789_init_cmds[cmd].databytes&0x1F);
         if (st7789_init_cmds[cmd].databytes & 0x80) {
-                vTaskDelay(100 / portTICK_RATE_MS);
+                vTaskDelay(pdMS_TO_TICKS(100));
         }
         cmd++;
     }

--- a/lvgl_tft/st7789.c
+++ b/lvgl_tft/st7789.c
@@ -14,6 +14,7 @@
 
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 
 /*********************
  *      DEFINES

--- a/lvgl_tft/st7796s.c
+++ b/lvgl_tft/st7796s.c
@@ -91,9 +91,9 @@ void st7796s_init(void)
 
 	//Reset the display
 	gpio_set_level(ST7796S_RST, 0);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 	gpio_set_level(ST7796S_RST, 1);
-	vTaskDelay(100 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 
 	ESP_LOGI(TAG, "Initialization.");
@@ -106,7 +106,7 @@ void st7796s_init(void)
 		st7796s_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes & 0x1F);
 		if (init_cmds[cmd].databytes & 0x80)
 		{
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}

--- a/lvgl_tft/st7796s.c
+++ b/lvgl_tft/st7796s.c
@@ -9,6 +9,7 @@
 #include "st7796s.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/lvgl_touch/adcraw.c
+++ b/lvgl_touch/adcraw.c
@@ -8,6 +8,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include <stddef.h>
 
 #if CONFIG_LV_TOUCH_CONTROLLER_ADCRAW

--- a/lvgl_touch/stmpe610.c
+++ b/lvgl_touch/stmpe610.c
@@ -63,7 +63,7 @@ void stmpe610_init(void)
 	
     // Attempt a software reset
 	write_8bit_reg(STMPE_SYS_CTRL1, STMPE_SYS_CTRL1_RESET);
-	vTaskDelay(10 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(10));
 	
 	// Reset the SPI configuration, making sure auto-increment is set
 	u8 = read_8bit_reg(STMPE_SPI_CFG);


### PR DESCRIPTION
ESP-IDF v5.0.0 incorporates a major update to the real-time kernel and number of other changes. This is my quick stab at adding support for the new toolchain version before the official release. Tested on the M5Stack Core2 for AWS IoT EduKit and works great.

There are memory and performance advantages to using `pdMS_TO_TICKS` instead of `portTICK_PERIOD_MS` or the deprecated `portTICK_RATE_MS` macros. That's why you'll see mostly universal changes that switches to that.