### PR TITLE
Update to support ESP-IDF v5 in develop branch

### DIFF
--- a/lv_port/esp_lcd_backlight.c
+++ b/lv_port/esp_lcd_backlight.c
@@ -9,7 +9,6 @@
 #include "esp_lcd_backlight.h"
 #include "driver/ledc.h"
 #include "driver/gpio.h"
-#include "rom/gpio.h"
 #include "esp_log.h"
 #include "soc/ledc_periph.h" // to invert LEDC output on IDF version < v4.3
 #include "esp_idf_version.h"
@@ -62,15 +61,25 @@ disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
 
         ESP_ERROR_CHECK(ledc_timer_config(&LCD_backlight_timer));
         ESP_ERROR_CHECK(ledc_channel_config(&LCD_backlight_channel));
+
+        #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+        esp_rom_gpio_connect_out_signal(config->gpio_num, ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx, config->output_invert, 0);
+        #else
         gpio_matrix_out(config->gpio_num, ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx, config->output_invert, 0);
+        #endif
     }
     else
     {
         // Configure GPIO for output
         bckl_dev->index = config->gpio_num;
-        gpio_pad_select_gpio(config->gpio_num);
         ESP_ERROR_CHECK(gpio_set_direction(config->gpio_num, GPIO_MODE_OUTPUT));
+        #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+        esp_rom_gpio_pad_select_gpio(config->gpio_num);
+        esp_rom_gpio_connect_out_signal(config->gpio_num, SIG_GPIO_OUT_IDX, config->output_invert, false);
+        #else
+        gpio_pad_select_gpio(config->gpio_num);
         gpio_matrix_out(config->gpio_num, SIG_GPIO_OUT_IDX, config->output_invert, false);
+        #endif
     }
 
     return (disp_backlight_h)bckl_dev;

--- a/lv_port/esp_lcd_backlight.c
+++ b/lv_port/esp_lcd_backlight.c
@@ -9,8 +9,14 @@
 #include "esp_lcd_backlight.h"
 #include "driver/ledc.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "esp_log.h"
 #include "soc/ledc_periph.h" // to invert LEDC output on IDF version < v4.3
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#include "soc/gpio_sig_map.h"
+#endif
 
 typedef struct {
     bool pwm_control; // true: LEDC is used, false: GPIO is used

--- a/lvgl_i2c/i2c_manager.c
+++ b/lvgl_i2c/i2c_manager.c
@@ -66,8 +66,8 @@ static const uint8_t ACK_CHECK_EN = 1;
 		#define I2C_MANAGER_0_PULLUPS 	false
 	#endif
 
-	#define I2C_MANAGER_0_TIMEOUT 		( CONFIG_I2C_MANAGER_0_TIMEOUT / portTICK_RATE_MS )
-	#define I2C_MANAGER_0_LOCK_TIMEOUT	( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT / portTICK_RATE_MS )
+	#define I2C_MANAGER_0_TIMEOUT 		( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_TIMEOUT ) )
+	#define I2C_MANAGER_0_LOCK_TIMEOUT	( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT ) )
 #endif
 
 
@@ -79,8 +79,8 @@ static const uint8_t ACK_CHECK_EN = 1;
 		#define I2C_MANAGER_1_PULLUPS 	false
 	#endif
 
-	#define I2C_MANAGER_1_TIMEOUT 		( CONFIG_I2C_MANAGER_1_TIMEOUT / portTICK_RATE_MS )
-	#define I2C_MANAGER_1_LOCK_TIMEOUT	( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT / portTICK_RATE_MS )
+	#define I2C_MANAGER_1_TIMEOUT 		( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_TIMEOUT ) )
+	#define I2C_MANAGER_1_LOCK_TIMEOUT	( pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT ) )
 #endif
 
 #define ERROR_PORT(port, fail) { \
@@ -222,7 +222,7 @@ esp_err_t I2C_FN(_read)(i2c_port_t port, uint16_t addr, uint32_t reg, uint8_t *b
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);
@@ -244,12 +244,12 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
 	TickType_t timeout = 0;
 	#if defined (I2C_ZERO)
 		if (port == I2C_NUM_0) {
-			timeout = (CONFIG_I2C_MANAGER_0_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_TIMEOUT );
 		}
 	#endif
 	#if defined (I2C_ONE)
 		if (port == I2C_NUM_1) {
-			timeout = (CONFIG_I2C_MANAGER_1_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_TIMEOUT );
 		}
 	#endif
 
@@ -271,7 +271,7 @@ esp_err_t I2C_FN(_write)(i2c_port_t port, uint16_t addr, uint32_t reg, const uin
 	}
 
     if (result != ESP_OK) {
-    	ESP_LOGW(TAG, "Error: %d", result);
+    	ESP_LOGD(TAG, "Error: %d", result);
     }
 
 	ESP_LOG_BUFFER_HEX_LEVEL(TAG, buffer, size, ESP_LOG_VERBOSE);
@@ -294,12 +294,12 @@ esp_err_t I2C_FN(_lock)(i2c_port_t port) {
 	TickType_t timeout;
 	#if defined (I2C_ZERO)
 		if (port == I2C_NUM_0) {
-			timeout = (CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_0_LOCK_TIMEOUT );
 		}
 	#endif
 	#if defined (I2C_ONE)
 		if (port == I2C_NUM_1) {
-			timeout = (CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT) / portTICK_RATE_MS;
+			timeout = pdMS_TO_TICKS( CONFIG_I2C_MANAGER_1_LOCK_TIMEOUT );
 		}
 	#endif
 

--- a/lvgl_tft/FT81x.c
+++ b/lvgl_tft/FT81x.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "driver/gpio.h"
+#include "esp_idf_version.h"
 
 #include "FT81x.h"
 

--- a/lvgl_tft/FT81x.c
+++ b/lvgl_tft/FT81x.c
@@ -263,7 +263,11 @@ void TFT_bitmap_display(void)
 void FT81x_init(void)
 {
 #if EVE_USE_PDN
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+	esp_rom_gpio_pad_select_gpio(EVE_PDN);
+#else
 	gpio_pad_select_gpio(EVE_PDN);
+#endif
 #endif
 
 	gpio_set_level(EVE_CS, 1);

--- a/lvgl_tft/GC9A01.c
+++ b/lvgl_tft/GC9A01.c
@@ -121,7 +121,7 @@ void GC9A01_init(void)
 		GC9A01_send_cmd(GC_init_cmds[cmd].cmd);
 		GC9A01_send_data(GC_init_cmds[cmd].data, GC_init_cmds[cmd].databytes&0x1F);
 		if (GC_init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}
@@ -235,8 +235,8 @@ static void GC9A01_reset(void)
 #if GC9A01_USE_RST
     //Reset the display
     gpio_set_level(GC9A01_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(GC9A01_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -280,6 +280,6 @@ static void hx8357_reset(void)
     gpio_set_level(HX8357_RST, 0);
     vTaskDelay(pdMS_TO_TICKS(10));
     gpio_set_level(HX8357_RST, 1);
-    vTaskDelaypdMS_TO_TICKS(120);
+    vTaskDelay(pdMS_TO_TICKS(120));
 #endif
 }

--- a/lvgl_tft/hx8357.c
+++ b/lvgl_tft/hx8357.c
@@ -176,7 +176,7 @@ void hx8357_init(void)
             }
         }
         if (x & 0x80) {       // If high bit set...
-            vTaskDelay(numArgs * 5 / portTICK_RATE_MS); // numArgs is actually a delay time (5ms units)
+            vTaskDelay(numArgs * pdMS_TO_TICKS(5)); // numArgs is actually a delay time (5ms units)
         }
     }
 
@@ -278,8 +278,8 @@ static void hx8357_reset(void)
 {
 #if HX8357_USE_RST
     gpio_set_level(HX8357_RST, 0);
-    vTaskDelay(10 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(10));
     gpio_set_level(HX8357_RST, 1);
-    vTaskDelay(120 / portTICK_RATE_MS);
+    vTaskDelaypdMS_TO_TICKS(120);
 #endif
 }

--- a/lvgl_tft/il3820.c
+++ b/lvgl_tft/il3820.c
@@ -30,7 +30,6 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
  *********************/
 #include "disp_spi.h"
 #include "driver/gpio.h"
-#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 

--- a/lvgl_tft/il3820.c
+++ b/lvgl_tft/il3820.c
@@ -30,6 +30,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
  *********************/
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -249,14 +250,14 @@ static void il3820_waitbusy(int wait_ms)
 {
     int i = 0;
 
-    vTaskDelay(10 / portTICK_RATE_MS); // 10ms delay
+    vTaskDelay(pdMS_TO_TICKS(10)); // 10ms delay
 
     for(i = 0; i < (wait_ms * 10); i++) {
 	if(gpio_get_level(IL3820_BUSY_PIN) != IL3820_BUSY_LEVEL) {
             return;
         }
 
-        vTaskDelay(10 / portTICK_RATE_MS);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
     LV_LOG_ERROR("Busy exceeded %dms", i*10 );
@@ -404,9 +405,9 @@ static void il3820_reset(void)
 #if IL3820_USE_RST
     /* Harware reset */
     gpio_set_level( IL3820_RST_PIN, 0);
-    vTaskDelay(IL3820_RESET_DELAY / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(IL3820_RESET_DELAY));
     gpio_set_level( IL3820_RST_PIN, 1);
-    vTaskDelay(IL3820_RESET_DELAY / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(IL3820_RESET_DELAY));
 #endif
 
     /* Software reset */

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -9,7 +9,6 @@
 #include "ili9163c.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
-#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "assert.h"

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -145,7 +145,7 @@ void ili9163c_init(void)
 		ili9163c_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes & 0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80)
 		{
-			vTaskDelaypdMS_TO_TICKS(150);
+			vTaskDelay(pdMS_TO_TICKS(150));
 		}
 		cmd++;
 	}
@@ -242,7 +242,7 @@ static void ili9163c_reset(void)
     gpio_set_level(ILI9163C_RST, 0);
     vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9163C_RST, 1);
-    vTaskDelaypdMS_TO_TICKS(150);
+    vTaskDelay(pdMS_TO_TICKS(150);
 #else
 #endif
 }

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -241,7 +241,7 @@ static void ili9163c_reset(void)
     gpio_set_level(ILI9163C_RST, 0);
     vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9163C_RST, 1);
-    vTaskDelay(pdMS_TO_TICKS(150);
+    vTaskDelay(pdMS_TO_TICKS(150));
 #else
 #endif
 }

--- a/lvgl_tft/ili9163c.c
+++ b/lvgl_tft/ili9163c.c
@@ -9,6 +9,7 @@
 #include "ili9163c.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "assert.h"
@@ -144,7 +145,7 @@ void ili9163c_init(void)
 		ili9163c_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes & 0x1F);
 		if (ili_init_cmds[cmd].databytes & 0x80)
 		{
-			vTaskDelay(150 / portTICK_RATE_MS);
+			vTaskDelaypdMS_TO_TICKS(150);
 		}
 		cmd++;
 	}
@@ -239,9 +240,9 @@ static void ili9163c_reset(void)
 {
 #if CONFIG_LV_DISP_USE_RST
     gpio_set_level(ILI9163C_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9163C_RST, 1);
-    vTaskDelay(150 / portTICK_RATE_MS);
+    vTaskDelaypdMS_TO_TICKS(150);
 #else
 #endif
 }

--- a/lvgl_tft/ili9481.c
+++ b/lvgl_tft/ili9481.c
@@ -81,7 +81,7 @@ void ili9481_init(void)
         ili9481_send_cmd(ili_init_cmds[cmd].cmd);
         ili9481_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
         if (ili_init_cmds[cmd].databytes & 0x80) {
-            vTaskDelay(100 / portTICK_RATE_MS);
+            vTaskDelay(pdMS_TO_TICKS(100));
         }
         cmd++;
     }
@@ -195,12 +195,12 @@ static void ili9481_reset(void)
 {
 #if ILI9481_USE_RST
     gpio_set_level(ILI9481_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9481_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #else
     // Exit sleep, software reset
     ili9481_send_cmd(0x01);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }

--- a/lvgl_tft/ili9486.c
+++ b/lvgl_tft/ili9486.c
@@ -73,7 +73,7 @@ void ili9486_init(void)
         ili9486_send_cmd(ili_init_cmds[cmd].cmd);
         ili9486_send_data(ili_init_cmds[cmd].data, ili_init_cmds[cmd].databytes&0x1F);
         if (ili_init_cmds[cmd].databytes & 0x80) {
-                vTaskDelay(100 / portTICK_RATE_MS);
+                vTaskDelay(pdMS_TO_TICKS(100));
         }
         cmd++;
     }
@@ -169,8 +169,8 @@ static void ili9486_reset(void)
 {
 #if ILI9486_USE_RST
     gpio_set_level(ILI9486_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ILI9486_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }

--- a/lvgl_tft/ra8875.c
+++ b/lvgl_tft/ra8875.c
@@ -9,7 +9,6 @@
 #include "ra8875.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
-#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 

--- a/lvgl_tft/ra8875.c
+++ b/lvgl_tft/ra8875.c
@@ -9,6 +9,7 @@
 #include "ra8875.h"
 #include "disp_spi.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -284,21 +285,21 @@ void ra8875_sleep_in(void)
     ra8875_configure_clocks(false);
 
     ra8875_write_cmd(RA8875_REG_PWRR, 0x00);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
     ra8875_write_cmd(RA8875_REG_PWRR, 0x02);           // Power and Display Control Register (PWRR)
 }
 
 void ra8875_sleep_out(void)
 {
     ra8875_write_cmd(RA8875_REG_PWRR, 0x00);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 
     ra8875_configure_clocks(true);
 
     disp_spi_change_device_speed(-1);
 
     ra8875_write_cmd(RA8875_REG_PWRR, 0x80);           // Power and Display Control Register (PWRR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 }
 
 uint8_t ra8875_read_cmd(uint8_t cmd)
@@ -331,7 +332,7 @@ void ra8875_configure_clocks(bool high_speed)
     vTaskDelay(1);
 
     ra8875_write_cmd(RA8875_REG_PCSR, PCSR_VAL);            // Pixel Clock Setting Register (PCSR)
-    vTaskDelay(DIV_ROUND_UP(20, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(20, portTICK_PERIOD_MS));
 }
 
 static void ra8875_set_window(unsigned int xs, unsigned int xe, unsigned int ys, unsigned int ye)
@@ -370,8 +371,8 @@ static void ra8875_reset(void)
 {
 #if RA8875_USE_RST
     gpio_set_level(RA8875_RST, 0);
-    vTaskDelay(DIV_ROUND_UP(100, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(100, portTICK_PERIOD_MS));
     gpio_set_level(RA8875_RST, 1);
-    vTaskDelay(DIV_ROUND_UP(100, portTICK_RATE_MS));
+    vTaskDelay(DIV_ROUND_UP(100, portTICK_PERIOD_MS));
 #endif
 }

--- a/lvgl_tft/sh1107.c
+++ b/lvgl_tft/sh1107.c
@@ -102,7 +102,7 @@ void sh1107_init(void)
         sh1107_send_cmd(init_cmds[cmd].cmd);
         sh1107_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes&0x1F);
         if (init_cmds[cmd].databytes & 0x80) {
-            vTaskDelay(100 / portTICK_RATE_MS);
+            vTaskDelay(pdMS_TO_TICKS(100));
         }
         cmd++;
     }
@@ -250,8 +250,8 @@ static void sh1107_reset(void)
 {
 #if SH1107_USE_RST
     gpio_set_level(SH1107_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(SH1107_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }

--- a/lvgl_tft/st7735s.c
+++ b/lvgl_tft/st7735s.c
@@ -109,7 +109,7 @@ void st7735s_init(void)
 		st7735s_send_cmd(init_cmds[cmd].cmd);
 		st7735s_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes&0x1F);
 		if (init_cmds[cmd].databytes & 0x80) {
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 		}
 		cmd++;
 	}
@@ -219,9 +219,9 @@ static void st7735s_reset(void)
 {
 #if ST7735S_USE_RST
     gpio_set_level(ST7735S_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ST7735S_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }
 

--- a/lvgl_tft/st7796s.c
+++ b/lvgl_tft/st7796s.c
@@ -92,7 +92,7 @@ void st7796s_init(void)
             st7796s_send_data(init_cmds[cmd].data, init_cmds[cmd].databytes & 0x1F);
             if (init_cmds[cmd].databytes & 0x80)
             {
-                    vTaskDelay(100 / portTICK_RATE_MS);
+                    vTaskDelay(pdMS_TO_TICKS(100));
             }
             cmd++;
     }
@@ -203,8 +203,8 @@ static void st7796s_reset(void)
 {
 #if ST7796S_USE_RST
     gpio_set_level(ST7796S_RST, 0);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
     gpio_set_level(ST7796S_RST, 1);
-    vTaskDelay(100 / portTICK_RATE_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 #endif
 }

--- a/lvgl_touch/adcraw.c
+++ b/lvgl_touch/adcraw.c
@@ -138,10 +138,19 @@ static void setup_axis(gpio_num_t plus, gpio_num_t minus, gpio_num_t measure, gp
 {
     // Set GPIOs:
     // - Float "ignore" and "measure"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+	esp_rom_gpio_pad_select_gpio(ignore);
+#else
     gpio_pad_select_gpio(ignore);
+#endif
     gpio_set_direction(ignore, GPIO_MODE_DISABLE);
     gpio_set_pull_mode(ignore, GPIO_FLOATING);
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+	esp_rom_gpio_pad_select_gpio(ignore);
+#else
     gpio_pad_select_gpio(measure);
+#endif
     gpio_set_direction(measure, GPIO_MODE_DISABLE);
     gpio_set_pull_mode(measure, GPIO_FLOATING);
     // - Set "plus" to 1, "minus" to 0

--- a/lvgl_touch/adcraw.c
+++ b/lvgl_touch/adcraw.c
@@ -8,6 +8,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
+#include "esp_idf_version.h"
 #include <stddef.h>
 
 #if CONFIG_LV_TOUCH_CONTROLLER_ADCRAW

--- a/lvgl_touch/stmpe610.c
+++ b/lvgl_touch/stmpe610.c
@@ -60,7 +60,7 @@ void stmpe610_init(void)
 	
     // Attempt a software reset
 	write_8bit_reg(STMPE_SYS_CTRL1, STMPE_SYS_CTRL1_RESET);
-	vTaskDelay(10 / portTICK_RATE_MS);
+	vTaskDelay(pdMS_TO_TICKS(10));
 	
 	// Reset the SPI configuration, making sure auto-increment is set
 	u8 = read_8bit_reg(STMPE_SPI_CFG);


### PR DESCRIPTION
Shifting PR https://github.com/lvgl/lvgl_esp32_drivers/pull/184 to develop branch instead. This has all the past changes. Tested against ESP-IDF prerelease-v5.0 and release-v4.4 on the M5Stack Core2 for AWS using a modified version of this example: https://github.com/lvgl/lv_port_esp32/tree/feat/new_driver_test

ESP-IDF v5.0.0 incorporates a major update to the real-time kernel and number of other changes. This is my quick stab at adding support for the new toolchain version before the official release. Tested on the M5Stack Core2 for AWS IoT EduKit and works great.

There are memory and performance advantages to using pdMS_TO_TICKS instead of portTICK_PERIOD_MS or the deprecated portTICK_RATE_MS macros. That's why you'll see mostly universal changes that switches to that.