### PR TITLE
fix missing SPI_HOST_MAX

### DIFF
--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -154,7 +154,11 @@ bool lvgl_spi_driver_init(int host,
     int dma_channel,
     int quadwp_pin, int quadhd_pin)
 {
-    assert((0 <= host) && (SPI_HOST_MAX > host));
+#if defined (SPI_HOST_MAX)
+    assert((SPI1_HOST <= host) && (SPI_HOST_MAX > host));
+#else
+    assert((SPI1_HOST <= host) && ((SPI3_HOST + 1) > host));
+#endif
     const char *spi_names[] = {
         "SPI1_HOST", "SPI2_HOST", "SPI3_HOST"
     };


### PR DESCRIPTION
Fix compilation issue
```
                 from components/lvgl_esp32_drivers/lvgl_helpers.h:18,
                 from components/lvgl_esp32_drivers/lvgl_helpers.c:10:
components/lvgl_esp32_drivers/lvgl_helpers.c: In function 'lvgl_spi_driver_init':
components/lvgl_esp32_drivers/lvgl_helpers.c:157:28: error: 'SPI_HOST_MAX' undeclared (first use in this function); did you mean 'GPIO_PORT_MAX'?
     assert((0 <= host) && (SPI_HOST_MAX > host));
                            ^~~~~~~~~~~~
components/lvgl_esp32_drivers/lvgl_helpers.c:157:28: note: each undeclared identifier is reported only once for each function it appears in
*** [.pio/build/esp32doit-devkit-v1-sergey/components/lvgl_esp32_drivers/lvgl_helpers.o] Error 1
```
Fix taken from develop branch: https://github.com/lvgl/lvgl_esp32_drivers/blob/develop/lvgl_helpers.c#L270 by @C47D 