### PR TITLE
Add a delay to avoid filling the log

### DIFF
--- a/lvgl_tft/ili9488.c
+++ b/lvgl_tft/ili9488.c
@@ -119,7 +119,10 @@ void ili9488_flush(lv_disp_drv_t * drv, const lv_area_t * area, lv_color_t * col
     uint8_t *mybuf;
     do {
         mybuf = (uint8_t *) heap_caps_malloc(3 * size * sizeof(uint8_t), MALLOC_CAP_DMA);
-        if (mybuf == NULL)  ESP_LOGW(TAG, "Could not allocate enough DMA memory!");
+        if (mybuf == NULL) {
+		    ESP_LOGW(TAG, "Could not allocate enough DMA memory! (wait");
+			vTaskDelay(1000);
+		} 
     } while (mybuf == NULL);
 
     uint32_t LD = 0;


### PR DESCRIPTION
I added this to be able to be able to track down a memory leak that doesn't happen for a long time, without it the driver immediately filling up any reasonable scrollback. 

Also, IMHO there is no reason to hammer heap_caps_malloc as that probably just prolongs any time it would take for the memory to be available. And likely more than most delays.

Just a though.
