### PR TITLE
Fix ESP-IDF configuration server error when enabling I2C ports 0 and 1

### DIFF
--- a/lvgl_i2c/Kconfig
+++ b/lvgl_i2c/Kconfig
@@ -6,10 +6,10 @@ menu "I2C Port 0"
 	if I2C_MANAGER_0_ENABLED
 		config I2C_MANAGER_0_SDA
 			int "SDA (GPIO pin)"
-			default 0
+			default -1
 		config I2C_MANAGER_0_SCL
 			int "SCL (GPIO pin)"
-			default 0
+			default -1
 		config I2C_MANAGER_0_FREQ_HZ
 			int "Frequency (Hz)"
 			default 400000
@@ -57,8 +57,10 @@ menu "I2C Port 1"
 	if I2C_MANAGER_1_ENABLED
 		config I2C_MANAGER_1_SDA
 			int "SDA (GPIO pin)"
+            default -1
 		config I2C_MANAGER_1_SCL
 			int "SCL (GPIO pin)"
+            default -1
 		config I2C_MANAGER_1_FREQ_HZ
 			int "Frequency (Hz)"
 			default 1000000


### PR DESCRIPTION
Fix ESP-IDF configuration server error when enabling I2C ports 0 and 1 (#115). The previous fix (#132) only fixed the problem for I2C port 0.