### PR TITLE
Use automatic DMA channel selection in ESP-IDF 4.4.4 and above & change deprecated field

### DIFF
--- a/lv_port/esp_lcd_backlight.c
+++ b/lv_port/esp_lcd_backlight.c
@@ -54,7 +54,7 @@ disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
         };
         const ledc_timer_config_t LCD_backlight_timer = {
             .speed_mode = LEDC_LOW_SPEED_MODE,
-            .bit_num = LEDC_TIMER_10_BIT,
+            .duty_resolution = LEDC_TIMER_10_BIT,
             .timer_num = config->timer_idx,
             .freq_hz = 5000,
             .clk_cfg = LEDC_AUTO_CLK};

--- a/lvgl_helpers.c
+++ b/lvgl_helpers.c
@@ -82,6 +82,13 @@ void lvgl_interface_init(void)
 
     ESP_LOGI(TAG, "Display buffer size: %d", display_buffer_size);
 
+    int dma_channel;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 4)
+    dma_channel = SPI_DMA_CH_AUTO;
+#else
+    dma_channel = 1;
+#endif
+
 #if defined (CONFIG_LV_TFT_DISPLAY_CONTROLLER_FT81X)
     init_ft81x(dma_channel);
     return;
@@ -99,9 +106,8 @@ void lvgl_interface_init(void)
     miso = TP_SPI_MISO;
 #endif
 
-    // We use DMA channel 1 for all cases
     lvgl_spi_driver_init(TFT_SPI_HOST, miso, DISP_SPI_MOSI, DISP_SPI_CLK,
-        spi_max_transfer_size, 1, DISP_SPI_IO2, DISP_SPI_IO3);
+        spi_max_transfer_size, dma_channel, DISP_SPI_IO2, DISP_SPI_IO3);
 
     disp_spi_add_device(TFT_SPI_HOST);
 
@@ -124,7 +130,11 @@ void lvgl_interface_init(void)
     ESP_LOGI(TAG, "Initializing SPI master for touch");
 
 #if defined (CONFIG_IDF_TARGET_ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 4)
+    dma_channel = SPI_DMA_CH_AUTO;
+#else
     dma_channel = 2;
+#endif
 #endif
 
     lvgl_spi_driver_init(TOUCH_SPI_HOST, TP_SPI_MISO, TP_SPI_MOSI, TP_SPI_CLK,


### PR DESCRIPTION
* DMA channel can be selected automatically in ESP-IDF 4.4.4 and above according to the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/v4.4.4/esp32/api-reference/peripherals/spi_master.html)
![Screenshot from 2023-02-05 09-58-30](https://user-images.githubusercontent.com/22185413/216797869-60ff82e9-dbf9-4db5-b0c4-ebd7aa0d3728.png)

* The bit_num field is deprecated in ESP-IDF 3.0, and ESP-IDF 5.0 is no longer backward compatible for this. Change its name to duty_resolution.
![Screenshot from 2023-02-05 09-49-41](https://user-images.githubusercontent.com/22185413/216797902-9ea4461d-f87e-4d85-b634-798c0bc68dbf.png)
